### PR TITLE
security: deep backend audit — fixes (1H/7M/LOWs) + crate refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,14 +250,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever 0.39.0",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -409,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -861,8 +860,6 @@ checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -874,14 +871,11 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex",
  "http 1.4.2",
- "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
  "url",
- "zeroize",
 ]
 
 [[package]]
@@ -984,56 +978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-sso"
-version = "1.102.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c82b3ac19f1431854f7ace3a7531674633e286bfdde21976893bfee36fd493b"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.104.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321000d2b4c5519ee573f73167f612efd7329322d9b26969ad1979f0427f1913"
-dependencies = [
- "arc-swap",
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.2",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-sts"
 version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,19 +1015,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
- "p256",
  "percent-encoding",
  "sha2 0.11.0",
- "subtle",
  "time",
  "tracing",
- "zeroize",
 ]
 
 [[package]]
@@ -1160,18 +1100,12 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.15",
- "http 0.2.12",
  "http 1.4.2",
- "http-body 0.4.6",
- "hyper 0.14.32",
  "hyper 1.10.1",
- "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls 0.23.41",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1525,12 +1459,6 @@ name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
-
-[[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base32"
@@ -2752,18 +2680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2736,17 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "dtoa-short",
+ "itoa",
  "smallvec",
 ]
 
@@ -4004,20 +3931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,26 +3964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4276,16 +4169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -4766,7 +4649,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -5083,17 +4965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,17 +5222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5386,23 +5246,22 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -5489,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -5551,7 +5410,6 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "log",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -6309,18 +6167,18 @@ dependencies = [
  "fastrand",
  "futures-io",
  "futures-util",
- "hostname",
  "httpdate",
  "idna",
  "mime",
- "native-tls",
  "nom 8.0.0",
  "percent-encoding",
  "quoted_printable",
+ "rustls 0.23.41",
  "socket2 0.6.4",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "url",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6653,14 +6511,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "match_token"
-version = "0.35.0"
+name = "markup5ever"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
+ "log",
+ "tendril 0.5.0",
+ "web_atoms 0.2.5",
 ]
 
 [[package]]
@@ -7860,18 +7718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "palette"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8434,15 +8280,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -9239,16 +9076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
 name = "rfd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9644,7 +9471,6 @@ dependencies = [
  "tower-http",
  "tower-livereload",
  "tower-sessions",
- "tower-sessions-core 0.9.1",
  "tower-sessions-redis-store",
  "tower_governor",
  "tracing",
@@ -9950,20 +9776,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "secrecy"
@@ -11787,23 +11599,6 @@ dependencies = [
 
 [[package]]
 name = "tower-cookies"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd0118512cf0b3768f7fcccf0bef1ae41d68f2b45edc1e77432b36c97c56c6d"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "cookie",
- "futures-util",
- "http 1.4.2",
- "parking_lot",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-cookies"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "151b5a3e3c45df17466454bb74e9ecedecc955269bdedbf4d150dfa393b55a36"
@@ -11883,35 +11678,12 @@ dependencies = [
  "http 1.4.2",
  "time",
  "tokio",
- "tower-cookies 0.11.0",
+ "tower-cookies",
  "tower-layer",
  "tower-service",
- "tower-sessions-core 0.14.0",
+ "tower-sessions-core",
  "tower-sessions-memory-store",
  "tracing",
-]
-
-[[package]]
-name = "tower-sessions-core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12564616434c7c811a229a223552b984f272e772d5dec4f71e61ca5bea7d3a3f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "futures",
- "http 1.4.2",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "tower-cookies 0.10.0",
- "tower-layer",
- "tower-service",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -11944,7 +11716,7 @@ dependencies = [
  "async-trait",
  "time",
  "tokio",
- "tower-sessions-core 0.14.0",
+ "tower-sessions-core",
 ]
 
 [[package]]
@@ -11958,7 +11730,7 @@ dependencies = [
  "rmp-serde",
  "thiserror 2.0.18",
  "time",
- "tower-sessions-core 0.14.0",
+ "tower-sessions-core",
 ]
 
 [[package]]

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -57,13 +57,13 @@ billing = []
 rux-auth = { path = "./crates/rux-auth" }
 migration = { path = "./migration" }
 ruxlog-types = { path = "../../crates/ruxlog-types", features = ["backend", "slug"] }
-axum = { version = "0.8.4", features = ["multipart"] }
+axum = { version = "0.8.9", features = ["multipart"] }
 axum-extra = { version = "0.10.1", features = [
     "typed-header",
     "cookie",
     "query",
 ] }
-sea-orm = { version = "1.1.0", features = [
+sea-orm = { version = "1.1.2", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
@@ -82,8 +82,8 @@ axum-valid = { version = "0.23.0", default-features = false, features = [
 ] }
 serde_json = "1.0.130"
 tower-livereload = "0.9.6"
-tokio = { version = "1.44.2", features = ["full"] }
-serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.45", features = ["full"] }
+serde = { version = "1.0.225", features = ["derive"] }
 # validator = { version = "0.16.1", features = ["derive"] }
 tower-http = { version = "0.6.2", features = [
     "trace",
@@ -93,7 +93,6 @@ tower-http = { version = "0.6.2", features = [
     "fs",
 ] }
 tower_governor = "0.4.2"
-tower-sessions-core = "0.9.0"
 tower-sessions-redis-store = "0.16.0"
 tower-sessions = { version = "0.14", features = ["private"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
@@ -122,16 +121,44 @@ rand_chacha = "0.9"
 clap = { version = "4.5", features = ["derive"] }
 fred = { version = "10.1.0", features = ["sha-1", "i-scripts", "enable-rustls"] }
 axum-client-ip = "1.0.0"
-lettre = { version = "0.11.22", features = ["default", "tokio1-native-tls"] }
-regex = "1.11.1"
+# DEPS-NATIVE-TLS-1: standardize outbound TLS on rustls. The prior
+# `tokio1-native-tls` feature pulled OpenSSL into the default build via the SMTP
+# path while the rest of the stack (sea-orm, fred, AWS SDK) is rustls-only.
+# `tokio1-rustls-tls` provides the async executor + rustls STARTTLS/TLS backend
+# for `AsyncSmtpTransport`; `smtp-transport` + `builder` are the transports and
+# message builder the mailer uses. native-tls / OpenSSL is no longer linked.
+lettre = { version = "0.11.22", default-features = false, features = [
+    "smtp-transport",
+    "builder",
+    "tokio1-rustls-tls",
+] }
+regex = "1.12"
 lazy_static = "1.5.0"
 async-trait = "0.1.88"
 tera = "1"
 log = "0.4.27"
 
-aws-config = { version = "1.6.2", features = ["behavior-version-latest"] }
-aws-sdk-s3 = "1.83.0"
-uuid = { version = "1.16.0", features = ["v4", "fast-rng"] }
+# DEPS-AWS-SDK-LEGACY-TLS: the AWS SDK's *default* features compile BOTH the
+# legacy HTTPS stack (hyper 0.14 + rustls 0.21 + rustls-webpki 0.101, which
+# carries RUSTSEC-2026-0098/0099/0104 — name-constraint bypass + CRL panic) and
+# the modern one (hyper 1.x + rustls 0.23 + aws-lc-rs + webpki 0.103). The app
+# only ever uses the modern client (aws_config::from_env() + Client::new() in
+# main.rs:144-159; no HyperClientBuilder/legacy path). Setting
+# default-features = false on BOTH crates and opting into rt-tokio +
+# default-https-client removes the entire legacy stack from every build, after
+# which the three deny.toml RUSTSEC ignores can be deleted. Both crates must be
+# changed together or cargo feature-unification re-pulls the legacy stack.
+aws-config = { version = "1.6.2", default-features = false, features = [
+    "behavior-version-latest",
+    "rt-tokio",
+    "default-https-client",
+] }
+aws-sdk-s3 = { version = "1.83.0", default-features = false, features = [
+    "behavior-version-latest",
+    "rt-tokio",
+    "default-https-client",
+] }
+uuid = { version = "1.17", features = ["v4", "fast-rng"] }
 base32 = "0.5.1"
 hmac = "0.12.1"
 sha1 = "0.10.6"
@@ -169,11 +196,25 @@ urlencoding = "2.1.3"
 imagesize = "0.12.0"
 bytes = "1.11.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "tiff"], optional = true }
-reqwest = { version = "0.12", features = ["json", "cookies"] }
+# DEPS-NATIVE-TLS-1: rustls for the direct HTTP client (Google userinfo, billing
+# providers). `default-features = false` drops reqwest's `default-tls`
+# (native-tls/OpenSSL); we re-add the non-TLS defaults we rely on (charset,
+# http2). TLS comes from `rustls-tls`, keeping the whole outbound TLS surface on
+# the audited rustls/webpki chain.
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "cookies",
+    "rustls-tls",
+    "charset",
+    "http2",
+] }
 maxminddb = "0.27"
 tower = { version = "0.5", features = ["util"] }
 oauth2 = { version = "4.4", optional = true }
-jsonwebtoken = { version = "10.2.0", features = ["aws_lc_rs"] }
+# jsonwebtoken: raise the floor to 10.4 — CVE-2026-25537 (type confusion)
+# affects <10.3.0. The root lockfile already resolves 10.4.0; pinning the floor
+# here guarantees a future resolve can never pull a vulnerable 10.2.x.
+jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
 ratatui = "0.29"
 crossterm = "0.29"
 tuirealm = "3.2.0"

--- a/backend/api/migration/Cargo.toml
+++ b/backend/api/migration/Cargo.toml
@@ -17,8 +17,8 @@ async-std = { version = "1.13.1", features = ["attributes", "tokio1"] }
 chrono = "0.4.41"
 clap = { version = "4.5.37", features = ["derive"] }
 dotenvy = "0.15.7"
-tokio = { version = "1.44.2", features = ["full"] }
-sea-orm = { version = "1.1.0", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros"] }
+tokio = { version = "1.45", features = ["full"] }
+sea-orm = { version = "1.1.2", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros"] }
 
 [dependencies.sea-orm-migration]
 version = "1.1.10"

--- a/backend/api/src/db/sea_models/newsletter_subscriber/actions.rs
+++ b/backend/api/src/db/sea_models/newsletter_subscriber/actions.rs
@@ -75,7 +75,18 @@ impl Entity {
 
         if let Some(model) = sub {
             // Only confirm if token matches and not already unsubscribed
-            if model.token == token && model.status != SubscriberStatus::Unsubscribed {
+            // CRYPT-NEWSLETTER-1: constant-time compare (the rest of the crypto
+            // surface uses subtle::ConstantTimeEq; the newsletter token was the
+            // lone `==` outlier). subtle is a direct dep and compiles without
+            // the billing feature, unlike services::billing::webhook_util.
+            use subtle::ConstantTimeEq;
+            let token_ok = model
+                .token
+                .as_bytes()
+                .ct_eq(token.as_bytes())
+                .unwrap_u8()
+                == 1;
+            if token_ok && model.status != SubscriberStatus::Unsubscribed {
                 let mut am: ActiveModel = model.into();
                 am.status = Set(SubscriberStatus::Confirmed);
                 am.updated_at = Set(now);
@@ -104,7 +115,10 @@ impl Entity {
         if let Some(model) = sub {
             // If a token is provided, require match
             if let Some(t) = token {
-                if model.token != t {
+                // CRYPT-NEWSLETTER-1: constant-time token compare.
+                use subtle::ConstantTimeEq;
+                let token_ok = model.token.as_bytes().ct_eq(t.as_bytes()).unwrap_u8() == 1;
+                if !token_ok {
                     return Ok(None);
                 }
             }

--- a/backend/api/src/db/sea_models/post/actions.rs
+++ b/backend/api/src/db/sea_models/post/actions.rs
@@ -631,17 +631,17 @@ impl Entity {
             }
         }
 
-        let post = Self::find_by_id(post_id).one(&transaction).await?;
-        if let Some(post_model) = post {
-            let mut post_active: ActiveModel = post_model.into();
-            post_active.view_count = Set(post_active.view_count.unwrap() + 1);
-            match post_active.update(&transaction).await {
-                Ok(_) => {}
-                Err(err) => {
-                    transaction.rollback().await?;
-                    return Err(err.into());
-                }
-            }
+        // RACE-VIEWCOUNT-1: atomic `UPDATE post SET view_count = view_count + 1`
+        // — no read-modify-write, so concurrent distinct-IP views (the dedup
+        // gate allows one per (post, ip) per window) cannot lose increments.
+        if let Err(err) = Self::update_many()
+            .col_expr(Column::ViewCount, Expr::col(Column::ViewCount).add(1))
+            .filter(Column::Id.eq(post_id))
+            .exec(&transaction)
+            .await
+        {
+            transaction.rollback().await?;
+            return Err(err.into());
         }
 
         // Commit the transaction

--- a/backend/api/src/db/sea_models/post_comment/actions.rs
+++ b/backend/api/src/db/sea_models/post_comment/actions.rs
@@ -177,6 +177,11 @@ impl Entity {
             .filter(Column::PostId.eq(post_id))
             .filter(Column::Hidden.eq(false))
             .order_by(Column::CreatedAt, Order::Asc)
+            // DOS-COMMENTLIST-1: cap the result set so a heavily-commented post
+            // cannot force an unbounded SELECT + 3-table join + serialization on
+            // every public request. 500 is a generous ceiling; true pagination
+            // (PER_PAGE) is used by the dashboard `find_with_query` path.
+            .limit(500)
             .into_model::<CommentWithUserJoined>()
             .all(conn)
             .await?;

--- a/backend/api/src/db/sea_models/user/actions.rs
+++ b/backend/api/src/db/sea_models/user/actions.rs
@@ -133,6 +133,11 @@ impl Entity {
         };
 
         if let Some(user_model) = user {
+            // EMAIL-CHANGE-1: capture the current email/verified state before
+            // the model is consumed by `into()`, so an email change can be
+            // detected and the stale trust state reset.
+            let prev_email = user_model.email.clone();
+            let prev_verified = user_model.is_verified;
             let mut user_active: ActiveModel = user_model.into();
 
             if let Some(name) = update_user.name {
@@ -140,7 +145,37 @@ impl Entity {
             }
 
             if let Some(email) = update_user.email {
-                user_active.email = Set(email);
+                if email != prev_email {
+                    // A verified account that changes its email must lose its
+                    // verified status until the NEW address is proven — otherwise
+                    // a verified badge persists on an unproven address the
+                    // account holder may not control (trust spoofing, CWE-290).
+                    // Rotate the per-user `session_auth_secret` so every prior
+                    // session is invalidated on its next request (the caller
+                    // must re-authenticate), mirroring the password-change path
+                    // (F#16). The new address is re-verified via the existing
+                    // email-verification resend endpoint.
+                    user_active.email = Set(email);
+                    user_active.is_verified = Set(false);
+                    user_active.session_auth_secret =
+                        Set(super::model::new_session_auth_secret().map_err(|err| {
+                            error!(
+                                user_id,
+                                "session_auth_secret rotation failed during email change: {err}"
+                            );
+                            ErrorResponse::new(ErrorCode::InternalServerError)
+                                .with_message(format!(
+                                    "session_auth_secret rotation failed: {err}"
+                                ))
+                        })?);
+                    info!(
+                        user_id,
+                        previously_verified = prev_verified,
+                        "Email changed: is_verified reset and prior sessions invalidated"
+                    );
+                } else {
+                    user_active.email = Set(email);
+                }
             }
 
             user_active.updated_at = Set(update_user.updated_at);

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -167,7 +167,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "image-optimization")]
     let optimizer = OptimizerConfig {
         enabled: env_bool("OPTIMIZE_ON_UPLOAD", true),
-        max_pixels: env_u64("OPTIMIZER_MAX_PIXELS", 40_000_000),
+        // DOS-MEDIA-OPTIMIZER: 12Mpx (~4000x3000) is ample for blog imagery and
+        // ~3x cheaper to decode/resize/re-encode than the prior 40Mpx default,
+        // which let a 2 MiB PNG declare ~40Mpx and pin a worker for seconds.
+        max_pixels: env_u64("OPTIMIZER_MAX_PIXELS", 12_000_000),
         keep_original: env_bool("OPTIMIZER_KEEP_ORIGINAL", true),
         default_webp_quality: env_u8("OPTIMIZER_WEBP_QUALITY_DEFAULT", 80),
     };

--- a/backend/api/src/modules/auth_v1/controller.rs
+++ b/backend/api/src/modules/auth_v1/controller.rs
@@ -71,6 +71,24 @@ pub async fn log_in(
     info!(client_ip = %secure_ip, "Login attempt");
 
     let payload = payload.0;
+
+    // AUTH-BF-1: per-account brute-force throttle on the password step. The
+    // generic per-IP 100/min cap on the /auth/v1 nest does not stop an attacker
+    // rotating source IPs from grinding one account's password with no
+    // account-level lockout. Key the abuse limiter on the normalized target
+    // email (same bucket shape the TOTP/2FA endpoints use for `totp:{user_id}`),
+    // so repeated guesses against one account trigger the temp/long block
+    // regardless of source IP. Fail-closed on Redis outage, matching the TOTP
+    // endpoints. (Accepted trade-off: an attacker who knows the email can lock
+    // the victim out — strictly better than unbounded password grinding.)
+    let login_key = payload.email.trim().to_lowercase();
+    abuse_limiter::limiter(
+        &state.redis_pool,
+        &format!("login:{login_key}"),
+        ABUSE_LIMITER_CONFIG,
+    )
+    .await?;
+
     let user = auth
         .backend()
         .authenticate_password(payload.email, payload.password)
@@ -434,7 +452,13 @@ pub async fn register(
         Err(err) => {
             warn!(error = ?err, "Registration failed");
             tracing::Span::current().record("result", "failure");
-            Err(err)
+            // AUTH-ENUM-REGISTER: do not surface the raw SeaORM error. A unique-
+            // violation ("Duplicate entry") is distinguishable from other
+            // failures via the ErrorCode/type field and leaks that the email is
+            // already registered. Return a generic message; the raw error type
+            // is no longer an enumeration oracle.
+            Err(ErrorResponse::new(ErrorCode::InternalServerError)
+                .with_message("Registration could not be completed at this time"))
         }
     }
 }

--- a/backend/api/src/modules/billing_v1/controller.rs
+++ b/backend/api/src/modules/billing_v1/controller.rs
@@ -697,6 +697,30 @@ pub async fn webhook_receiver(
                     .with_message(format!("Webhook verification failed: {}", e))
             })?;
 
+        // WEBHOOK-LS-RZP-NO-REPLAY-DEDUP: LemonSqueezy/Razorpay webhooks carry
+        // no timestamp, so a captured valid event was replayable (the GETDEL
+        // checkout-intent + provider_payment_id unique index already prevent a
+        // double-grant, but a replay re-ran idempotent processing + log noise).
+        // After signature verification (only authenticated bodies populate the
+        // set), dedup on (provider, sha256(body)) for 24h so only the first
+        // authenticated delivery is processed. Fail-open on a Redis blip (the
+        // GETDEL/unique-index backstops still hold).
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(body.as_ref());
+        let body_hash = hex::encode(hasher.finalize());
+        let dedup_key = format!("webhook:{provider}:{body_hash}");
+        if !crate::services::abuse_limiter::dedup_nx(&state.redis_pool, &dedup_key, 86_400)
+            .await
+            .unwrap_or(true)
+        {
+            tracing::info!(
+                provider = %provider,
+                "Replay webhook (already processed within 24h); acknowledging"
+            );
+            return Ok(Json(json!({ "received": true })));
+        }
+
         process_webhook_event(&state, &parsed, &provider).await?;
 
         Ok(Json(json!({ "received": true })))

--- a/backend/api/src/modules/google_auth_v1/controller.rs
+++ b/backend/api/src/modules/google_auth_v1/controller.rs
@@ -579,6 +579,23 @@ async fn find_or_create_user(
         return Ok(existing_user);
     }
 
+    // OAUTH-CREATE-UNVERIFIED: the link branch above (line ~552) refuses to bind
+    // a Google identity to an existing account unless the IdP verified the
+    // email. The CREATE branch must apply the SAME gate — otherwise an attacker
+    // who sets an unverified-at-Google primary email to a victim's address gets
+    // a brand-new verified (is_verified=true) local account in the victim's name
+    // (trust spoofing) and squats the email so the victim can never register.
+    // Fail closed: do not auto-create; the user signs up via normal email
+    // verification instead.
+    if !user_info.verified_email {
+        warn!(
+            email = %user_info.email,
+            "Refusing to create account from Google: IdP email is not verified"
+        );
+        return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+            .with_message("Google has not verified this email address"));
+    }
+
     info!("Creating new user from Google account");
     user::Entity::create_from_google(
         &state.sea_db,

--- a/backend/api/src/modules/media_v1/controller.rs
+++ b/backend/api/src/modules/media_v1/controller.rs
@@ -319,19 +319,40 @@ pub async fn create(
 
     #[cfg(feature = "image-optimization")]
     if content_type.starts_with("image/") {
-        let optimization_request = image_optimizer::OptimizationRequest {
-            bytes: &file_bytes,
-            metadata: &metadata,
-            reference: metadata.reference_type,
-            original_mime: mime_type.as_deref(),
-            original_extension: extension.as_deref(),
-        };
-
+        // DOS-MEDIA-OPTIMIZER: the `image` crate work (full RGBA decode +
+        // Lanczos3 resize/re-encode for up to 6 variants + a second validation
+        // decode per variant) is CPU/memory-heavy. Run it on a blocking thread
+        // so a burst of uploads cannot pin the async worker and head-of-line
+        // block every other request sharing that thread. (The /media/v1 nest is
+        // also rate-limited and OPTIMIZER_MAX_PIXELS is capped.)
+        let req_bytes = file_bytes.clone();
+        let req_metadata = metadata.clone();
+        let req_reference = metadata.reference_type;
+        let req_mime = mime_type.clone();
+        let req_ext = extension.clone();
+        let optimizer_cfg = state.optimizer.clone();
         let optimization_outcome =
-            match image_optimizer::optimize(&state.optimizer, optimization_request) {
-                Ok(outcome) => outcome,
-                Err(err) => {
+            match tokio::task::spawn_blocking(move || {
+                let optimization_request = image_optimizer::OptimizationRequest {
+                    bytes: &req_bytes,
+                    metadata: &req_metadata,
+                    reference: req_reference,
+                    original_mime: req_mime.as_deref(),
+                    original_extension: req_ext.as_deref(),
+                };
+                image_optimizer::optimize(&optimizer_cfg, optimization_request)
+            })
+            .await
+            {
+                Ok(Ok(outcome)) => outcome,
+                Ok(Err(err)) => {
                     warn!("image optimizer error: {}", err);
+                    image_optimizer::OptimizationOutcome::Skipped(
+                        image_optimizer::SkipReason::DecodeFailed,
+                    )
+                }
+                Err(err) => {
+                    warn!(error = %err, "image optimizer blocking task failed");
                     image_optimizer::OptimizationOutcome::Skipped(
                         image_optimizer::SkipReason::DecodeFailed,
                     )

--- a/backend/api/src/modules/media_v1/validator.rs
+++ b/backend/api/src/modules/media_v1/validator.rs
@@ -144,7 +144,7 @@ fn extension_for_mime(mime: &str) -> &'static str {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Validate)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, Validate)]
 pub struct MediaUploadMetadata {
     pub reference_type: Option<MediaReference>,
     pub width: Option<i32>,

--- a/backend/api/src/modules/newsletter_v1/controller.rs
+++ b/backend/api/src/modules/newsletter_v1/controller.rs
@@ -1,4 +1,5 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum_client_ip::ClientIp;
 use axum_macros::debug_handler;
 use lettre::{message::header::ContentType, AsyncTransport, Message};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -66,9 +67,10 @@ async fn send_mail(
 }
 
 #[debug_handler]
-#[instrument(skip(state, payload), fields(email = %payload.email))]
+#[instrument(skip(state, client_ip, payload), fields(email = %payload.email))]
 pub async fn subscribe(
     State(state): State<AppState>,
+    ClientIp(client_ip): ClientIp,
     payload: ValidatedJson<V1SubscribePayload>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
     let email = payload.email.trim().to_lowercase();
@@ -85,6 +87,23 @@ pub async fn subscribe(
         block_duration: 24 * 60 * 60,
     };
     limiter(&state.redis_pool, &key, config).await?;
+
+    // DOS-NEWSLETTER-IP-1: per-IP bucket. The per-email limiter above is
+    // defeated by rotating the email field; pair it with a per-IP bucket so a
+    // single source cannot flood inserts + outbound confirmation mail.
+    limiter(
+        &state.redis_pool,
+        &format!("newsletter:subscribe:ip:{client_ip}"),
+        AbuseLimiterConfig {
+            temp_block_attempts: 20,
+            temp_block_range: 60,
+            temp_block_duration: 60 * 60,
+            block_retry_limit: 200,
+            block_range: 24 * 60 * 60,
+            block_duration: 24 * 60 * 60,
+        },
+    )
+    .await?;
 
     let new_sub = NewSubscriber {
         email: email.clone(),

--- a/backend/api/src/modules/post_comment_v1/controller.rs
+++ b/backend/api/src/modules/post_comment_v1/controller.rs
@@ -12,8 +12,20 @@ use crate::{
     db::sea_models::{comment_flag, post_comment},
     error::{ErrorCode, ErrorResponse},
     extractors::ValidatedJson,
-    services::auth::AuthSession,
+    services::{abuse_limiter, auth::AuthSession},
     AppState,
+};
+
+/// DOS-COMMENT-CREATE-2: per-account comment throttle. The comment nest's
+/// per-IP 100/min layer alone lets one verified account behind rotating IPs
+/// flood comments; this bounds a single account (fail-closed on Redis).
+const COMMENT_ABUSE_CONFIG: abuse_limiter::AbuseLimiterConfig = abuse_limiter::AbuseLimiterConfig {
+    temp_block_attempts: 20,
+    temp_block_range: 60,
+    temp_block_duration: 600,
+    block_retry_limit: 100,
+    block_range: 3600,
+    block_duration: 3600,
 };
 
 use super::validator::{
@@ -29,6 +41,16 @@ pub async fn create(
     payload: ValidatedJson<V1CreatePostCommentPayload>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
     let user = auth.user.unwrap();
+
+    // DOS-COMMENT-CREATE-2: per-account throttle (the comment nest already has
+    // a per-IP 100/min layer; this bounds one account behind rotating IPs).
+    abuse_limiter::limiter(
+        &state.redis_pool,
+        &format!("comment:create:user:{}", user.id),
+        COMMENT_ABUSE_CONFIG,
+    )
+    .await?;
+
     let new_comment = payload.0.into_new_post_comment(user.id);
     tracing::Span::current().record("post_id", new_comment.post_id);
 

--- a/backend/api/src/modules/post_v1/controller.rs
+++ b/backend/api/src/modules/post_v1/controller.rs
@@ -1,9 +1,10 @@
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
     Json,
 };
+use axum_client_ip::ClientIp;
 
 use crate::db::sea_models::post::UpdatePost;
 use crate::db::sea_models::{post_revision, post_series, post_series_post, scheduled_post};
@@ -383,9 +384,43 @@ pub async fn track_view(
     State(state): State<AppState>,
     auth: AuthSession,
     Path(post_id): Path<i32>,
+    client_ip: ClientIp,
+    headers: HeaderMap,
 ) -> Result<impl IntoResponse, ErrorResponse> {
     let user_id: Option<i32> = auth.user.map(|user| user.id);
-    match post::Entity::increment_view_count(&state.sea_db, post_id, user_id, None, None).await {
+
+    // DOS-TRACKVIEW-2: dedup per (post, ip) in Redis BEFORE any DB write. The
+    // /post/v1 nest has a 200/min/IP cap, but an attacker rotating source IPs
+    // still got one post_view INSERT + post UPDATE per request (txn-per-request
+    // write load). This SET-NX gate collapses the writes to ≤1 per (post, ip)
+    // per 5-min window regardless of IP-pool size. Fail-open on a Redis blip.
+    let ip_str = client_ip.0.to_string();
+    let dedup_key = format!("trackview:{post_id}:{ip_str}");
+    let user_agent = headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+    if !crate::services::abuse_limiter::dedup_nx(&state.redis_pool, &dedup_key, 300)
+        .await
+        .unwrap_or(true)
+    {
+        // Already counted this (post, ip) within the window — short-circuit so
+        // we don't INSERT another post_view row or bump the counter again.
+        return Ok((
+            StatusCode::OK,
+            Json(json!({ "message": "View tracked successfully" })),
+        ));
+    }
+
+    match post::Entity::increment_view_count(
+        &state.sea_db,
+        post_id,
+        user_id,
+        Some(ip_str),
+        user_agent,
+    )
+    .await
+    {
         Ok(_) => Ok((
             StatusCode::OK,
             Json(json!({ "message": "View tracked successfully" })),

--- a/backend/api/src/modules/post_v1/validator.rs
+++ b/backend/api/src/modules/post_v1/validator.rs
@@ -359,7 +359,11 @@ pub struct V1PostQueryParams {
 impl V1PostQueryParams {
     pub fn into_post_query(self) -> PostQuery {
         PostQuery {
-            page_no: self.page,
+            // DOS-PUBLIST-OFFSET-1: clamp the page so a caller cannot drive an
+            // arbitrarily large OFFSET through the public published-listing
+            // multi-table join (same class as DOS-SEARCH-1). 500 × PER_PAGE
+            // bounds the offset regardless of the requested page.
+            page_no: self.page.map(|p| p.clamp(1, 500)),
             author_id: self.author_id,
             category_id: self.category_id,
             status: self.status,

--- a/backend/api/src/modules/search_v1/validator.rs
+++ b/backend/api/src/modules/search_v1/validator.rs
@@ -15,7 +15,10 @@ pub struct SearchQuery {
 
 impl SearchQuery {
     pub fn page(&self) -> u64 {
-        self.page.unwrap_or(1).max(1)
+        // DOS-SEARCH-1: cap the page so a caller cannot drive an arbitrarily
+        // large (and therefore expensive) OFFSET on top of the unindexed
+        // triple-ILIKE scan. 500 pages × 100 per_page bounds the offset to ~50k.
+        self.page.unwrap_or(1).clamp(1, 500)
     }
 
     pub fn per_page(&self) -> u64 {

--- a/backend/api/src/modules/user_v1/controller.rs
+++ b/backend/api/src/modules/user_v1/controller.rs
@@ -10,7 +10,7 @@ use tracing::{error, info, instrument, warn};
 
 use super::validator::*;
 use crate::{
-    db::sea_models::user::Entity as User,
+    db::sea_models::user::{Entity as User, UserRole},
     error::{ErrorCode, ErrorResponse},
     extractors::ValidatedJson,
     services::auth::AuthSession,
@@ -65,11 +65,36 @@ pub async fn update_profile(
 
 #[cfg(feature = "user-management")]
 #[debug_handler]
-#[instrument(skip(state, payload))]
+#[instrument(skip(auth, state, payload))]
 pub async fn admin_create(
+    auth: AuthSession,
     state: State<AppState>,
     payload: ValidatedJson<V1AdminCreateUserPayload>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
+    // PRIV-ESCAL-1: the route guard only requires ROLE_ADMIN. Enforce here that
+    // an admin cannot create a user whose role exceeds their own — otherwise an
+    // ADMIN could mint a SUPER_ADMIN, defeating the top tier that admin_acl_v1
+    // / seed_v1 gate with ROLE_SUPER_ADMIN.
+    let caller_level = auth
+        .user
+        .as_ref()
+        .map(|u| u.role.to_i32())
+        .ok_or_else(|| {
+            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+        })?;
+    let requested = UserRole::from_str(&payload.0.role).map_err(|_| {
+        ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role")
+    })?;
+    if requested.to_i32() > caller_level {
+        warn!(
+            caller_level,
+            requested = %payload.0.role,
+            "Admin attempted to create a user above their own role"
+        );
+        return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+            .with_message("You cannot create a user with a role higher than your own"));
+    }
+
     let payload = payload.0.into_new_user();
     let user = User::admin_create(&state.sea_db, &state.object_storage.public_url, payload).await?;
     info!(user_id = user.id, "Admin created user");
@@ -78,11 +103,39 @@ pub async fn admin_create(
 
 #[cfg(feature = "user-management")]
 #[debug_handler]
-#[instrument(skip(state), fields(user_id))]
+#[instrument(skip(auth, state), fields(user_id))]
 pub async fn admin_delete(
+    auth: AuthSession,
     state: State<AppState>,
     Path(user_id): Path<i32>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
+    // PRIV-ESCAL-1 (admin_delete): the sibling handlers (admin_create /
+    // admin_update / admin_change_password) all enforce the role hierarchy, but
+    // this one was missed — an ADMIN could delete a SUPER_ADMIN (or any peer
+    // ADMIN), destroying a superior's account and — if the last SUPER_ADMIN is
+    // removed — making the ROLE_SUPER_ADMIN-only seed/admin-acl routes
+    // permanently unreachable. Mirror the caller-vs-target check used by
+    // admin_change_password: forbid touching a user at/above the caller's own
+    // level, and forbid self-deletion through the admin path.
+    let caller = auth.user.ok_or_else(|| {
+        ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+    })?;
+    let caller_level = caller.role.to_i32();
+    if caller.id == user_id {
+        return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+            .with_message("You cannot delete your own account via the admin path"));
+    }
+    if let Some(target) = User::get_by_id(&state.sea_db, user_id).await? {
+        if target.role.to_i32() >= caller_level {
+            warn!(
+                caller_level,
+                target_level = target.role.to_i32(),
+                "Admin attempted to delete an equal/higher-role user"
+            );
+            return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+                .with_message("You cannot delete a user at or above your own role"));
+        }
+    }
     match User::admin_delete(&state.sea_db, user_id).await {
         Ok(1) => {
             info!(user_id, "Admin deleted user");
@@ -111,12 +164,54 @@ pub async fn admin_delete(
 
 #[cfg(feature = "user-management")]
 #[debug_handler]
-#[instrument(skip(state, payload), fields(user_id))]
+#[instrument(skip(auth, state, payload), fields(user_id))]
 pub async fn admin_update(
+    auth: AuthSession,
     state: State<AppState>,
     Path(user_id): Path<i32>,
     payload: ValidatedJson<V1AdminUpdateUserPayload>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
+    // PRIV-ESCAL-1: the route guard only requires ROLE_ADMIN, so enforce the
+    // role hierarchy here. (a) the requested role must not exceed the caller's
+    // own, and (b) the caller may not modify a user already at/above their own
+    // level. Together these close ADMIN -> SUPER_ADMIN self-escalation and the
+    // silent takeover primitive an admin had by editing/demoting a superior. An
+    // admin still manages their own profile via the self-service
+    // /user/v1/update endpoint, so blocking equal-rank edits here is safe.
+    let caller_level = auth
+        .user
+        .as_ref()
+        .map(|u| u.role.to_i32())
+        .ok_or_else(|| {
+            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+        })?;
+
+    if let Some(role_str) = payload.0.role.as_deref() {
+        let requested = UserRole::from_str(role_str)
+            .map_err(|_| ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role"))?;
+        if requested.to_i32() > caller_level {
+            warn!(
+                caller_level,
+                requested = role_str,
+                "Admin attempted to assign a role above their own"
+            );
+            return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+                .with_message("You cannot assign a role higher than your own"));
+        }
+    }
+
+    if let Some(target) = User::get_by_id(&state.sea_db, user_id).await? {
+        if target.role.to_i32() >= caller_level {
+            warn!(
+                caller_level,
+                target_level = target.role.to_i32(),
+                "Admin attempted to modify an equal/higher-role user"
+            );
+            return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+                .with_message("You cannot modify a user at or above your own role"));
+        }
+    }
+
     let payload = payload.0.into_update_user();
     match User::admin_update(
         &state.sea_db,
@@ -144,12 +239,34 @@ pub async fn admin_update(
 
 #[cfg(feature = "user-management")]
 #[debug_handler]
-#[instrument(skip(state, payload), fields(user_id))]
+#[instrument(skip(auth, state, payload), fields(user_id))]
 pub async fn admin_change_password(
+    auth: AuthSession,
     state: State<AppState>,
     Path(user_id): Path<i32>,
     payload: ValidatedJson<AdminChangePassword>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
+    // PRIV-ESCAL-1: forbid resetting the password of a user at/above the
+    // caller's own level — otherwise an ADMIN could set a known password on a
+    // SUPER_ADMIN account (account takeover of a superior).
+    let caller_level = auth
+        .user
+        .as_ref()
+        .map(|u| u.role.to_i32())
+        .ok_or_else(|| {
+            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+        })?;
+    if let Some(target) = User::get_by_id(&state.sea_db, user_id).await? {
+        if target.role.to_i32() >= caller_level {
+            warn!(
+                caller_level,
+                target_level = target.role.to_i32(),
+                "Admin attempted to reset password of an equal/higher-role user"
+            );
+            return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
+                .with_message("You cannot reset the password of a user at or above your own role"));
+        }
+    }
     User::change_password(&state.sea_db, user_id, payload.0.password).await?;
     info!(user_id, "Admin changed user password");
     Ok((

--- a/backend/api/src/router.rs
+++ b/backend/api/src/router.rs
@@ -44,6 +44,8 @@ use crate::modules::seed_v1;
 #[cfg(feature = "billing")]
 use crate::modules::billing_v1;
 
+use crate::utils::sanitize::xml_escape;
+
 use super::AppState;
 
 pub fn router(state: AppState) -> Router<AppState> {
@@ -77,7 +79,14 @@ pub fn router(state: AppState) -> Router<AppState> {
             .nest("/forgot_password/v1", forgot_password_v1::routes());
     }
 
-    router = router.nest("/post/v1", post_v1::routes());
+    // DOS-TRACKVIEW-1: the public `track_view` endpoint writes a DB transaction
+    // per call, so the whole post nest gets a generous per-IP cap (reads are
+    // cheap SELECTs; 200/min/IP is ample for a real user and bounds a flooder
+    // that previously hit the txn-per-request view counter unbounded).
+    router = router.nest(
+        "/post/v1",
+        post_v1::routes().layer(rate_limit::RateLimitLayer::new(state.clone(), 200, 60)),
+    );
 
     #[cfg(feature = "comments")]
     {
@@ -94,9 +103,21 @@ pub fn router(state: AppState) -> Router<AppState> {
     router = router
         .nest("/category/v1", category_v1::routes())
         .nest("/tag/v1", tag_v1::routes())
-        .nest("/media/v1", media_v1::routes())
+        // DOS-MEDIA-OPTIMIZER: the upload path runs the CPU-heavy image
+        // optimizer; give /media/v1 its own tight per-IP cap (it is also
+        // author-gated) so a burst of uploads cannot monopolize workers.
+        .nest(
+            "/media/v1",
+            media_v1::routes().layer(rate_limit::RateLimitLayer::new(state.clone(), 30, 60)),
+        )
         .nest("/feed/v1", feed_v1::routes())
-        .nest("/search/v1", search_v1::routes());
+        // DOS-SEARCH-1: search runs a triple leading-wildcard ILIKE (full table
+        // scan) per request and was previously un-rate-limited. 30/min/IP bounds
+        // an anonymous caller cheaply minting a CSRF token then replaying it.
+        .nest(
+            "/search/v1",
+            search_v1::routes().layer(rate_limit::RateLimitLayer::new(state.clone(), 30, 60)),
+        );
 
     #[cfg(feature = "newsletter")]
     {
@@ -223,8 +244,13 @@ async fn sitemap_xml(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let base_url =
+    let raw_base_url =
         std::env::var("CONSUMER_SITE_URL").unwrap_or_else(|_| "https://ruxlog.com".to_string());
+    // SITEMAP-XML-1: escape both the operator base URL and every post slug
+    // before interpolating into XML. Slugs are author-controlled and only
+    // length-validated, so unescaped interpolation is a stored XML-injection
+    // vector. `feed_v1` already escapes its RSS output the same way.
+    let base_url = xml_escape(&raw_base_url);
 
     let mut urls = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
     urls.push_str(&format!(
@@ -234,9 +260,10 @@ async fn sitemap_xml(
 
     for p in &posts {
         let lastmod = p.updated_at.to_rfc3339();
+        let slug = xml_escape(&p.slug);
         urls.push_str(&format!(
             "  <url><loc>{}/posts/{}</loc><lastmod>{}</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>\n",
-            base_url, p.slug, lastmod
+            base_url, slug, lastmod
         ));
     }
 

--- a/backend/api/src/services/abuse_limiter.rs
+++ b/backend/api/src/services/abuse_limiter.rs
@@ -258,3 +258,32 @@ pub async fn limiter(
         }
     }
 }
+
+/// One-shot dedup gate: atomic `SET key 1 EX ttl NX`.
+///
+/// Returns `Ok(true)` when the key was newly created (the caller should proceed
+/// with the gated work) and `Ok(false)` when it already existed (the caller
+/// should short-circuit — the work was already recorded this window).
+///
+/// Used by `track_view` to bound DB writes to ≤1 per (post, ip) per window
+/// regardless of source-IP rotation (DOS-TRACKVIEW-2). Fail-OPEN on a Redis
+/// error: a dedup outage must not 5xx the public view tracker — the per-IP nest
+/// rate limit still bounds the floor.
+pub async fn dedup_nx(
+    redis_pool: &RedisPool,
+    key: &str,
+    ttl_secs: usize,
+) -> Result<bool, ErrorResponse> {
+    const DEDUP: &str =
+        "return redis.call('SET', KEYS[1], '1', 'EX', ARGV[1], 'NX') and 1 or 0";
+    let keys = vec![key.to_string()];
+    let args: Vec<Value> = vec![Value::from(ttl_secs as i64)];
+    let res: Result<Vec<Value>, _> = redis_pool.eval(DEDUP, keys, args).await;
+    match res {
+        Ok(v) => Ok(v.first().and_then(to_u64).unwrap_or(0) == 1),
+        Err(err) => {
+            warn!(error = %err, %key, "dedup check failed (fail-open)");
+            Ok(true)
+        }
+    }
+}

--- a/backend/api/src/services/acl_service.rs
+++ b/backend/api/src/services/acl_service.rs
@@ -44,6 +44,21 @@ impl AclService {
             if normalized_key.is_empty() {
                 continue;
             }
+            // ACL-ENV-SECRETS-IMPORT: never persist live secret material into
+            // the `app_constants` table / shared Redis hash. The prior
+            // `guess_sensitive` heuristic both missed common secret names
+            // (DATABASE_URL, REDIS_URL, SMTP_URL, CONNECTION_STRING, PGCONN) and
+            // — critically — only controlled read-side masking, leaving every
+            // caught secret (COOKIE_KEY, FIELD_ENC_KEY, AWS_SECRET_ACCESS_KEY)
+            // stored VERBATIM at rest. Skipping secret keys entirely closes the
+            // at-rest duplication of the process's highest-value secrets.
+            if Self::looks_like_secret_key(&normalized_key) {
+                tracing::debug!(
+                    key = %normalized_key,
+                    "Skipping secret env var during import_env (not persisted)"
+                );
+                continue;
+            }
             let is_sensitive =
                 Self::guess_sensitive(&normalized_key) || Self::guess_sensitive(&value);
 
@@ -73,6 +88,73 @@ impl AclService {
             || lower.contains("token")
             || lower.contains("key")
             || lower.contains("access")
+    }
+
+    /// ACL-ENV-SECRETS-IMPORT: comprehensive secret-key detector. A key that
+    /// looks like a secret is SKIPPED by `bootstrap_from_env` (never persisted
+    /// to Postgres or the shared Redis hash). This is a deny-list that covers
+    /// the bypasses the prior `guess_sensitive` heuristic missed
+    /// (DATABASE_URL / REDIS_URL / SMTP_URL / CONNECTION_STRING / *_DSN) plus
+    /// the explicit ruxlog live-crypto/session names (COOKIE_KEY,
+    /// FIELD_ENC_KEY) and cloud/provider credentials.
+    fn looks_like_secret_key(key: &str) -> bool {
+        let k = key.to_ascii_uppercase();
+        // Explicit secret-bearing substrings (case-insensitive).
+        const SECRET_NEEDLES: &[&str] = &[
+            "SECRET",
+            "PASSWORD",
+            "PASSWD",
+            "TOKEN",
+            "CREDENTIAL",
+            "PRIVATE",
+            "SIGNING",
+            "APIKEY",
+            // connection strings / infra URLs that carry or target credentials:
+            "DATABASE_URL",
+            "DB_URL",
+            "DSN",
+            "PGCONN",
+            "CONNECTION_STRING",
+            "CONNECTIONSTRING",
+            "REDIS_URL",
+            "REDIS_TLS_URL",
+            "SMTP_URL",
+            "SMTP_PASS",
+            "MAIL_PASSWORD",
+            "AMQP",
+            "RABBITMQ",
+            "KAFKA",
+            // ruxlog live crypto / session material — must never be duplicated:
+            "COOKIE_KEY",
+            "FIELD_ENC_KEY",
+            "SESSION_KEY",
+            "CSRF_KEY",
+            "JWT_SECRET",
+            // cloud / provider credentials:
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SESSION_TOKEN",
+            "STRIPE",
+            "PADDLE",
+            "LEMON",
+            "RAZORPAY",
+            "MERCADO",
+            "GOOGLE_CLIENT_SECRET",
+            "OAUTH_CLIENT_SECRET",
+        ];
+        // Suffixes that mark a var as secret regardless of prefix.
+        const SECRET_SUFFIXES: &[&str] = &[
+            "_KEY",
+            "_SECRET",
+            "_TOKEN",
+            "_PASSWORD",
+            "_PASSWD",
+            "_PWD",
+            "_CREDENTIAL",
+            "_CREDENTIALS",
+        ];
+        SECRET_NEEDLES.iter().any(|n| k.contains(n))
+            || SECRET_SUFFIXES.iter().any(|s| k.ends_with(s))
     }
 
     pub async fn get_constant(

--- a/backend/api/src/services/billing/mercado_pago.rs
+++ b/backend/api/src/services/billing/mercado_pago.rs
@@ -145,7 +145,25 @@ impl BillingProvider for MercadoPagoProvider {
     ) -> Result<CheckoutSession, BillingError> {
         let client = self.http_client.clone();
 
-        let body = serde_json::json!({
+        // SSRF-MP-NOTIFICATIONURL-1: notification_url MUST NOT be derived from
+        // the user-controlled success_url — Mercado Pago POSTs webhook events to
+        // it, so a caller could name an internal URL and have the provider probe
+        // it (provider-mediated SSRF). Build it from an operator-configured
+        // public base + the app's own webhook path; omit it if unconfigured (the
+        // dashboard-configured webhook URL then applies).
+        let notification_url = std::env::var("MERCADO_PAGO_WEBHOOK_URL")
+            .ok()
+            .map(|u| u.trim().to_string())
+            .filter(|u| !u.is_empty())
+            .or_else(|| {
+                std::env::var("CONSUMER_SITE_URL")
+                    .ok()
+                    .map(|base| {
+                        format!("{}/billing/v1/webhook/mercado_pago", base.trim_end_matches('/'))
+                    })
+            });
+
+        let mut body = serde_json::json!({
             "items": [
                 {
                     "title": format!("Plan: {}", plan_slug),
@@ -164,8 +182,10 @@ impl BillingProvider for MercadoPagoProvider {
             },
             "auto_return": "approved",
             "external_reference": user_id.to_string(),
-            "notification_url": success_url,
         });
+        if let Some(url) = notification_url {
+            body["notification_url"] = serde_json::Value::String(url);
+        }
 
         let resp = client
             .post(format!("{}/checkout/preferences", self.base_url))

--- a/backend/api/src/services/scheduler.rs
+++ b/backend/api/src/services/scheduler.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::db::sea_models::post::{ActiveModel, Column, Entity, PostStatus};
 use crate::state::AppState;
@@ -49,6 +49,36 @@ async fn publish_due_posts(state: &AppState) -> Result<(), sea_orm::DbErr> {
     let count = due_posts.len();
     for post in due_posts {
         let post_id = post.id;
+        let author_id = post.author_id;
+
+        // SCHED-TOCTOU-AUTHZ: re-assert at fire time that the author may still
+        // publish. The request-time handler checked ownership + Author role when
+        // the post was scheduled, but a background tick must not publish on
+        // behalf of a principal who has since been demoted below Author or whose
+        // account was removed (orphaned FK) — otherwise the scheduler is a
+        // TOCTOU bypass of the publish authorization.
+        let author_ok = match crate::db::sea_models::user::Entity::find_by_id(author_id)
+            .one(&state.sea_db)
+            .await
+        {
+            Ok(Some(u)) => u.is_author(),
+            Ok(None) => false,
+            Err(err) => {
+                error!(
+                    post_id, author_id, error = %err,
+                    "Scheduler author re-check failed; skipping publish"
+                );
+                false
+            }
+        };
+        if !author_ok {
+            warn!(
+                post_id, author_id,
+                "Skipping scheduled publish: author no longer authorized"
+            );
+            continue;
+        }
+
         let mut active: ActiveModel = post.into();
         active.status = Set(PostStatus::Published);
         if let Err(err) = active.update(&state.sea_db).await {

--- a/backend/api/src/utils/sanitize.rs
+++ b/backend/api/src/utils/sanitize.rs
@@ -138,6 +138,29 @@ where
     }
 }
 
+/// Escape a string for safe interpolation into XML text/attribute content.
+///
+/// Escapes the five XML 1.0 metacharacters (`&`, `<`, `>`, `'`, `"`). Used for
+/// server-generated XML documents (the sitemap) where author/operator-controlled
+/// strings (post slugs, the site base URL) are interpolated into the document —
+/// preventing stored XML injection / structure breakage (SITEMAP-XML-1). Slugs
+/// are author-controlled and only length-validated, so without this a post slug
+/// like `</loc></url><!--` would corrupt or inject into `/sitemap.xml`.
+pub fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '\'' => out.push_str("&apos;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/deny.toml
+++ b/deny.toml
@@ -41,17 +41,13 @@ ignore = [
     # any built target. Pure lockfile-residual risk.
     { id = "RUSTSEC-2023-0071", reason = "rsa Marvin: no upstream fix; not in the built graph; no RSA ops in ruxlog." },
 
-    # rustls-webpki 0.101.7 — three advisories (CRL panic, URI-name-constraint
-    # mis-acceptance, wildcard-name-constraint mis-acceptance). 0.101.7 is
-    # pinned by rustls 0.21.12, which is itself pinned by aws-smithy-http-client
-    # (via aws-config / aws-sdk-s3) for one internal HTTPS path. No patched
-    # rustls 0.21.x exists; the fix lives in rustls-webpki >=0.103.x, reached
-    # only by moving the AWS SDK off rustls 0.21. Unavoidable while on the SDK.
-    # The rest of our TLS surface (fred, native-tls/openssl, sea-orm) is on
-    # rustls 0.23 / openssl >=0.10.72 and unaffected.
-    { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.101.7 CRL panic; pinned by AWS SDK rustls 0.21, no 0.21.x patch." },
-    { id = "RUSTSEC-2026-0098", reason = "rustls-webpki 0.101.7 URI name-constraint bug; pinned by AWS SDK rustls 0.21." },
-    { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.101.7 wildcard name-constraint bug; pinned by AWS SDK rustls 0.21." },
+    # DEPS-AWS-SDK-LEGACY-TLS (resolved 2026-06-30): the AWS SDK is now on
+    # default-features = false (backend/api/Cargo.toml), which removed the
+    # legacy hyper-0.14 + rustls-0.21 + rustls-webpki-0.101 stack entirely —
+    # only rustls-webpki 0.103.x remains. The three RUSTSEC-2026-0098/0099/0104
+    # ignores that used to suppress webpki 0.101.7's name-constraint / CRL
+    # advisories are therefore deleted (verified: `cargo tree` shows no
+    # rustls 0.21 / webpki 0.101 / hyper 0.14 in the graph).
 
     # async-std 1.13.x — "has been discontinued" (unmaintained). Pulled directly
     # by our `migration` path-crate (SeaORM migration tooling), which is why the

--- a/docs/SECURITY_AUDIT_2026-06-30.md
+++ b/docs/SECURITY_AUDIT_2026-06-30.md
@@ -1,0 +1,165 @@
+# ruxlog Backend Security Audit — 2026-06-30 (independent re-audit)
+
+**Scope:** `backend/api` (axum 0.8 + SeaORM 1.1 + Redis) and the `rux-auth` session-auth crate.
+**Method:** fresh, independent 16-dimension multi-agent audit (IDOR read × writes, vertical privesc,
+auth/session, OAuth/OIDC, 2FA, SQLi, validation/mass-assignment, XSS/stored content, CSRF,
+SSRF/open-redirect/traversal, webhook crypto, DoS/rate-limit, secrets/crypto/config, deps/CVE,
+fix-regression) with **adversarial per-finding verification** (each finding re-checked by an
+independent verifier that tried to refute it against the real code), a **completeness-critic** pass,
+and a **targeted re-find** round on the gaps the critic raised. **60 agents, 2.58M tokens, 1,110 tool
+calls.** Every "Fixed" item below was re-verified by `cargo check` (default **and** `full`) and
+`cargo test --lib` (**265 + 539 passed, 0 failed**).
+
+> This pass re-audits the working tree that already contains the 2026-06-29 audit's 10 applied fixes.
+> Findings are against the **current** code; a prior fix that is incomplete or buggy IS a finding
+> here (see `PRIV-ESCAL-1` / `admin_delete`).
+
+## Headline
+
+The authorization model remains sound. **No cross-user IDOR** was found on posts, series, revisions,
+comments, media/variants/usage, likes/flags, billing reads, or analytics — every id-bearing handler
+filters by the session user (or a correctly-bounded admin/moderator override) at the query layer,
+not just the route-role gate. **No SQL injection** is reachable (every `Expr::cust`/raw builder was
+traced to integer-only or operator-config input). OAuth PKCE/OIDC, session fixation/revocation,
+CSRF (per-session HMAC-bound token, exact-match exempt list), constant-time compares, and Argon2id
+are all intact.
+
+This pass's confirmed issues are: **one HIGH** (`admin_delete` privesc — the one gap in the prior
+PRIV-ESCAL fix), **seven MEDIUM** (a DoS class on default-build public endpoints, a Google-OAuth
+verified-email gap, a Mercado Pago SSRF, the AWS-SDK legacy-TLS CVE stack, and an admin secret-import
+blast-radius bug), and a batch of **LOW/INFO** defense-in-depth items. All HIGH + all MEDIUM + the
+cleanest LOWs are **fixed this pass**; the remainder are documented with exact fix recipes.
+
+## Result matrix
+
+| Sev | Status this pass |
+|---|---|
+| **High** | `IDOR-USER-ADMIN-DELETE` ADMIN→SUPER_ADMIN account deletion (the `admin_delete` gap in PRIV-ESCAL-1) — **FIXED** |
+| **Medium** | `OAUTH-CREATE-UNVERIFIED`, `SSRF-MP-NOTIFICATIONURL-1`, `DOS-PUBLIST-OFFSET-1`, `DEPS-AWS-SDK-LEGACY-TLS`, `ACL-ENV-SECRETS-IMPORT`, `DOS-TRACKVIEW-2`, `DOS-MEDIA-OPTIMIZER` — **ALL FIXED** |
+| **Low (fixed)** | `DOS-TRACKVIEW-NO-DEDUP-1`, `RACE-VIEWCOUNT-1`, `SCHED-TOCTOU-AUTHZ`, `AUTH-ENUM-REGISTER`, `WEBHOOK-LS-RZP-NO-REPLAY-DEDUP` — **FIXED** |
+| **Low (deferred, exact fix below)** | `EMAIL-CHANGE-NO-REVERIFY-MAIL`, `LOGIN-LOCKOUT-DOS`, `2FA-BACKUP-TOCTOU`, `2FA-DISABLE-NO-REAUTH`, `BILLING-DEAD-VALIDATORS`, `CSRF-GET-MUTATE-1`, `OPENREDIR-BILLING-1`, `CRYPT-NEWSLETTER-PLAINTEXT-AT-REST`, `BILLING-METADATA-EXPOSE` |
+| **Info (fixed)** | `DEPS-TOWER-SESSIONS-CORE-DEAD`, `DEPS-FLOOR-CLEANUP` — **FIXED** (crate refresh) |
+| **Info (deferred)** | `2FA-DISABLE-LEAK-MISMATCH`, `XSS-COMMENT-CONTENT-NO-SANITIZE` |
+| **Non-issue** | `ENUM-POSTID-VIEW` (published-id walk; data already public via `/list/published`, unpublished-existence oracle closed) |
+| **Refuted (auditor overstated)** | `XSS-MAIL-TERA-NOAUTOESCAPE` (Tera autoescapes by default), `DOS-NOGLOBAL-BODYLIMIT-1` (per-nest limits suffice), `DOS-IMGDECODE-HEADER-TRUST-1` (header can't bypass the pixel budget; `image` re-decodes), `ROUTE-BLOCKER-SILENT-NOOP` (layer order defeats the alleged bypass), `HSTS-UNCONDITIONAL-PLAINTEXT` (deployment assumption, documented), `CORS-CREDENTIALED-ORIGIN-APPEND` (SameSite=Lax defeats the alleged credentialed read) |
+
+## Fixed this pass
+
+### `IDOR-USER-ADMIN-DELETE` — HIGH — `admin_delete` missed by PRIV-ESCAL-1
+The 2026-06-29 PRIV-ESCAL-1 fix added a caller-vs-target role check to `admin_create`,
+`admin_update`, and `admin_change_password` — but **not** `admin_delete`. An ADMIN could
+`POST /user/v1/admin/delete/{super_admin_id}` and destroy a SUPER_ADMIN (and, by deleting the last
+one, make `seed_v1`/`admin_acl_v1` permanently unreachable). **Fix:** `admin_delete` now takes the
+caller's `AuthSession`, forbids self-deletion, and rejects deleting a user at/above the caller's
+level — mirroring `admin_change_password`. (`user_v1/controller.rs`)
+
+### `DOS-PUBLIST-OFFSET-1` — MED — unbounded OFFSET on public post list
+`POST /post/v1/list/published` (public) passed `page` straight to an unbounded `OFFSET` on a
+multi-table join — same class as the already-fixed `DOS-SEARCH-1`, but the clamp was never applied
+here. **Fix:** `V1PostQueryParams::into_post_query` clamps `page` to `[1, 500]`. (`post_v1/validator.rs`)
+
+### `DOS-TRACKVIEW-2` + `DOS-TRACKVIEW-NO-DEDUP-1` + `RACE-VIEWCOUNT-1` — MED/LOW
+The prior `DOS-TRACKVIEW-1` fix added a per-IP rate limit but never the recommended per-(post,ip)
+Redis dedup, and the handler passed `None` IP/UA. A rotating-IP flooder still got one
+`post_view` INSERT + post UPDATE per request (txn-per-request), and the counter was a non-atomic
+read-modify-write (lost-update race). **Fix:** `track_view` now resolves the real `ClientIp` + UA,
+gates on a `trackview:{post}:{ip}` Redis `SET NX EX 300` (reusing a new `abuse_limiter::dedup_nx`),
+and `increment_view_count` is an atomic `UPDATE … SET view_count = view_count + 1`. Write load
+collapses to ≤1 per (post,ip) per 5 min regardless of IP-pool size. (`post_v1/controller.rs`,
+`post/actions.rs`, `services/abuse_limiter.rs`)
+
+### `OAUTH-CREATE-UNVERIFIED` — MED — Google OAuth create ignored IdP verified_email
+The link branch refused to bind a Google identity unless `verified_email`, but the CREATE branch
+created `is_verified=true` unconditionally — an attacker with an unverified-at-Google email set to a
+victim's address got a verified account in the victim's name + squatted the email. **Fix:** the
+create branch now applies the same `verified_email` gate (fail-closed). (`google_auth_v1/controller.rs`)
+
+### `SSRF-MP-NOTIFICATIONURL-1` — MED — Mercado Pago `notification_url` from user input
+`notification_url` was set verbatim from the user-controlled `success_url`; Mercado Pago POSTs
+webhook events to it (provider-mediated SSRF). **Fix:** `notification_url` is now built from an
+operator-configured base (`MERCADO_PAGO_WEBHOOK_URL`, else `CONSUMER_SITE_URL` + the app's own
+webhook path), never from `success_url`; omitted if unconfigured. (`services/billing/mercado_pago.rs`)
+
+### `ACL-ENV-SECRETS-IMPORT` — MED — `import_env` bulk-persisted all process env vars
+`/admin/acl/v1/import_env` iterated `std::env::vars()` and wrote **every** key/value (including
+`COOKIE_KEY`, `FIELD_ENC_KEY`, `DATABASE_URL`, `AWS_SECRET_ACCESS_KEY`, Redis URL) verbatim into the
+`app_constants` Postgres table **and** the shared Redis hash. The `guess_sensitive` heuristic both
+missed common secret names and only masked read-side (secrets sat plaintext at rest). **Fix:** a
+comprehensive `looks_like_secret_key` detector now **skips** secret keys entirely (never persisted).
+(`services/acl_service.rs`)
+
+### `DOS-MEDIA-OPTIMIZER` — MED — inline image decode pinned async workers
+`/media/v1` (unrate-limited) ran `image_optimizer::optimize` synchronously on the async thread;
+a near-max-pixel PNG pinned a worker for seconds. **Fix:** (1) the optimize call is wrapped in
+`tokio::task::spawn_blocking` (added `Clone` to `MediaUploadMetadata`); (2) `/media/v1` gets a
+30/min/IP rate limit; (3) `OPTIMIZER_MAX_PIXELS` default lowered 40M → 12Mpx. (`media_v1/controller.rs`,
+`media_v1/validator.rs`, `router.rs`, `main.rs`)
+
+### `DEPS-AWS-SDK-LEGACY-TLS` — MED — AWS SDK default features compiled the vulnerable legacy TLS stack
+`aws-config`/`aws-sdk-s3` with default features compiled rustls-0.21 + rustls-webpki-0.101 +
+hyper-0.14 (RUSTSEC-2026-0098/0099/0104 — name-constraint bypass + CRL panic). **Fix:** both crates
+now use `default-features = false` + `["behavior-version-latest","rt-tokio","default-https-client"]`.
+Verified via `cargo tree`: **no rustls 0.21 / webpki 0.101 / hyper 0.14 remain** (only
+`rustls-webpki 0.103`); the three stale `deny.toml` RUSTSEC ignores are deleted. The SSO SDKs that
+re-enabled the legacy stack are gone too. (`backend/api/Cargo.toml`, `deny.toml`)
+
+### `SCHED-TOCTOU-AUTHZ` — LOW — scheduled publisher skipped fire-time authz
+`publish_due_posts` transitioned any author's Draft→Published on the 60s tick with no fire-time
+re-check; an author demoted/removed after scheduling still got published (TOCTOU bypass of the
+publish authorization). **Fix:** each due post now re-loads its author and skips (logs) if the author
+no longer exists or is below Author role. (`services/scheduler.rs`)
+
+### `AUTH-ENUM-REGISTER` — LOW — register surfaced the raw duplicate DB error
+`register` propagated the raw SeaORM error, so a unique-violation's ErrorCode/type field leaked that
+the email exists. **Fix:** the failure path returns a generic message (the raw error type is no longer
+an oracle; success-vs-failure distinction remains and is documented). (`auth_v1/controller.rs`)
+
+### `WEBHOOK-LS-RZP-NO-REPLAY-DEDUP` — LOW — LemonSqueezy/Razorpay replay
+Those providers send no timestamp; a captured valid event was replayable (GETDEL + unique-index
+already prevented double-grant, but replay re-ran processing + log noise). **Fix:** after signature
+verification, `webhook_receiver` dedups on `(provider, sha256(body))` for 24h via `dedup_nx`
+(fail-open). (`billing_v1/controller.rs`)
+
+### Crate refresh (DEPS-FLOOR-CLEANUP, DEPS-TOWER-SESSIONS-CORE-DEAD)
+`cargo update` advanced all semver-compatible deps (ammonia, html5ever, time, …); `time` pinned to
+0.3.51 (0.3.52 breaks `cookie` 0.18's `parse`). Removed the unused `tower-sessions-core = "0.9.0"`
+direct dep (orphaned duplicate gone). Raised floors: `tokio 1.45`, `uuid 1.17`, `regex 1.12`,
+`serde 1.0.225`, migration `sea-orm 1.1.2`. `jsonwebtoken` already at the 10.4 CVE floor.
+
+**Build verification:** `cargo check` default ✅ + `full` ✅; `cargo test --lib` → **265 (default) +
+539 (full) passed, 0 failed**; `cargo tree` confirms the legacy TLS stack is gone.
+
+## Deferred (exact fix given — LOW/INFO, need wire-contract/schema/frontend change or a deliberate trade-off)
+
+| Finding | Fix |
+|---|---|
+| `EMAIL-CHANGE-NO-REVERIFY-MAIL` | After `User::update`'s email-change rotation, mint a code via `email_verification::Entity::generate_code` + `hash_code`, `regenerate` for the user, and fire `send_email_verification_code` to the new address (spawned), mirroring `auth_v1::register`. Closes the re-verification gap. |
+| `2FA-BACKUP-TOCTOU` | Make backup-code consumption atomic: a conditional `UPDATE … WHERE two_fa_backup_codes @> <consumed_hash>` (jsonb) checking `rows_affected > 0`, or a `SELECT … FOR UPDATE` inside the txn, so one code can't authorize two concurrent verifies. Also persist `updated_hashes` in `twofa_disable`. |
+| `BILLING-DEAD-VALIDATORS` | Switch the 7 billing body extractors `Json<T>` → `ValidatedJson<T>` (`create_checkout`, `create_post_checkout`, `admin_create_plan`, `admin_update_plan`, `admin_cancel_subscription`, `admin_create_discount_code`, `admin_set_post_access`) and add `#[validate(range(min = 0))]` to `SetPostAccessPayload.price_cents` so the rules actually fire. |
+| `OPENREDIR-BILLING-1` | Validate `success_url`/`cancel_url` against an origin allow-list (reuse the `FRONTEND_URL`/`OAUTH_ALLOWED_REDIRECT_ORIGINS` set; allow same-site relative `/…` not `//…`), defaulting to `/billing/success`/`/billing/cancel` otherwise. (The MED SSRF half is already fixed.) |
+| `BILLING-METADATA-EXPOSE` | Map `my_subscriptions`/`my_payments` results through `SubscriptionResponse`/`PaymentResponse` (`validator.rs:137/163`) instead of the raw `Model`, so `metadata` (payer PII) is dropped from consumer responses. |
+| `CRYPT-NEWSLETTER-PLAINTEXT-AT-REST` | Store the newsletter token as `hash_code(secret, token)` (mirror `email_verification`); confirm/unsubscribe look up by email and compare `hash_code(secret, submitted) == stored_hash`. Needs a nullable/hash column + backfill. |
+| `CSRF-GET-MUTATE-1` | Change `GET /admin/route/v1/sync` → `POST` (`admin_route_v1/mod.rs:19`) **and** the `frontend/admin-dioxus` call site — coordinate with the frontend. |
+| `2FA-DISABLE-NO-REAUTH` | Require the current password (+ fresh TOTP/backup) on `/2fa/disable` (extend `V1TwoFADisablePayload` with `password`, verify via `authenticate_password`); optionally invalidate other sessions on disable. |
+| `LOGIN-LOCKOUT-DOS` | Deliberate trade-off vs `AUTH-BF-1` (the per-account throttle just added). If mitigating: key the block on `(email, /24)` or require both email-bucket and IP-bucket near-threshold, so one attacker IP can't lock a victim account-wide. |
+| `2FA-DISABLE-LEAK-MISMATCH` | Align `twofa_disable` error messages with `twofa_verify` to remove minor 2FA-state inference. |
+| `XSS-COMMENT-CONTENT-NO-SANITIZE` | Run comment `content` through `ammonia::clean` at the write chokepoint — **but only after confirming the frontend renders comments as HTML, not `textContent`** (else server-side escaping double-encodes and shows `&lt;`). Document the assumption either way. |
+
+## Verified clean (re-confirmed this pass)
+IDOR on posts/series/revisions/comments/media(+variants/usage)/likes/flags/billing-reads/analytics;
+post `find_by_id_or_slug` status-gate (F#12) + paywall strip; media M-5/M-6/M-7 ownership + SVG
+allowlist; comment user-scoping; billing checkout-intent GETDEL + `provider_payment_id` unique-index
+idempotency (no double-grant); forgot-password single-use GETDEL + timing-equalization;
+csrf_guard per-session HMAC binding + exact-match exempt list; webhook signature verification
+(constant-time, before side effects) on the timestamp-bearing providers; OAuth PKCE + session-bound
+state + nonce + fail-closed link; session-id rotation on login; `session_auth_hash` rotation on
+password/email change (F#16); `tag_ids` `Expr::cust` is integer-only (not SQLi); the 10 prior-audit
+fixes are correct in the working tree (EMAIL-CHANGE-1, PRIV-ESCAL-1 save `admin_delete`, CRYPT-NEWSLETTER
+ct_eq, native-tls removal, etc.).
+
+## Methodology note
+All severities above were set or corrected by the *verifier*, not the finder. The verifier refuted
+4 finder findings outright (image-decode header-trust, mail-tera, global-body-limit, route_blocker)
+and downgraded others. The completeness critic's highest-value catch — `ACL-ENV-SECRETS-IMPORT` —
+was a surface outside the 16 dimensions (a deliberate admin endpoint duplicating live secrets into a
+weakly-governed store) and is fixed this pass.

--- a/docs/SECURITY_AUDIT_2026-06.md
+++ b/docs/SECURITY_AUDIT_2026-06.md
@@ -1,0 +1,230 @@
+# ruxlog Backend Security Audit — 2026-06-29
+
+**Scope:** `backend/api` (axum 0.8 + SeaORM 1.1 + Redis) and the `rux-auth` session-auth crate.
+**Method:** 14-dimension multi-agent audit (IDOR ×4, admin boundary, SQLi, auth/session, CSRF,
+crypto, webhook signatures, validation/mass-assignment, SSRF/traversal/redirect, DoS/rate-limit,
+deps/CVE/config) with **adversarial per-finding verification** against the real code, plus a
+completeness-critic pass. 52 agents, 968 tool calls. Every "confirmed" finding below was re-checked
+by an independent verifier that tried to refute it by reading the cited code; severities were
+corrected (mostly *down*) where the auditor overstated.
+
+**Headline:** the authorization model is fundamentally sound. **No cross-user IDOR was found** on
+posts, series, revisions, comments, media, or billing reads — every one of those handlers filters by
+the session user id (or a correctly-bounded admin/moderator override), and resource-level ownership
+is enforced at the query layer, not just at the route-role gate. The real issues are a handful of
+**abuse/DoS gaps on unauthenticated endpoints**, one **privilege-escalation** in the user-management
+admin path, one **trust-state bug** on email change, and a batch of **defense-in-depth hardening**
+items, most of them behind non-default feature flags.
+
+## Result matrix
+
+| Sev | Default build (OSS release) | Feature-gated (`full`) |
+|---|---|---|
+| **High** | `AUTH-BF-1` login has no per-account throttle · `DOS-TRACKVIEW-1` unauth view-track DoS | `PRIV-ESCAL-1` ADMIN→SUPER_ADMIN escalation |
+| **Medium** | `DOS-SEARCH-1` unauth unindexed ILIKE · `EMAIL-CHANGE-1` email change keeps verified · `SITEMAP-XML-1` stored XML injection | `DOS-COMMENTLIST-1` unbounded comment SELECT · `DOS-COMMENT-CREATE-2` no per-account comment throttle |
+| **Low** | `AUTH-REVOKE-FAILOPEN-1` revocation fails open on Redis blip · `DEPS-WEBPKI-1` rustls-webpki 0.101 via AWS SDK | `CSRF-GET-MUTATE-1` state-changing GET · `CRYPT-NEWSLETTER-1` token `==`+plaintext · `WEBHOOK-LS-RZP` no replay dedup · `BILLING-DEAD-VALIDATORS` raw `Json` · `OPENREDIR-BILLING-1` unvalidated redirect URLs · `BILLING-METADATA-EXPOSE` raw provider blob · `DOS-NEWSLETTER-IP-1` email-only throttle · `AUTH-ENUM-1` register enumeration |
+| **Info** | `DEPS-NATIVE-TLS-1` mixed TLS stack | `BILLING-ACCESS-INFO-1` paid-post enumeration |
+
+**Verified clean (no issue):** IDOR on posts/series/revisions, comments, media/variants/usage,
+billing reads & paywall content enforcement, OAuth (PKCE + session-bound CSRF state + verified-OIDC
+nonce + **fail-closed account linking**), password-change session invalidation (**F#16
+`session_auth_secret` rotation**), CSRF token binding, webhook signature verification on the 8
+timestamp-bearing providers, constant-time compares on HMACs/2FA/CSRF, Argon2id password hashing.
+
+**Refuted (auditor flagged, verifier disproved):** newsletter-unsubscribe token-optional (DB-layer
+only; HTTP always supplies token), media-URL `Expr::cust` SQLi (only operator-config + hardcoded
+literals reach it), Google OIDC nonce `==` (not attacker-controllable, no oracle), search raw-`Json`
+(validation is manually called), stale `backend/api/Cargo.lock` (workspace root always wins).
+
+---
+
+## Default-build findings (affect the open-source `basic` release)
+
+### `AUTH-BF-1` — HIGH — No per-account brute-force protection on password login
+`POST /auth/v1/log_in` (`auth_v1/controller.rs:74`) has only the generic per-IP 100/min limit on the
+whole `/auth/v1` nest. The TOTP/2FA endpoints call `abuse_limiter` (per-user bucket, 3/360s temp +
+5/900s hard block); **the password step does not.** An attacker rotating IPs can grind a weak
+password with no account-level lockout. Argon2id + per-IP cap bound single-IP throughput, but the
+aggregate is unbounded. **Fix:** call `abuse_limiter::limiter(&redis, format!("login:{email}"), …)`
+at the top of `log_in`, fail-closed, mirroring the TOTP endpoints.
+
+### `DOS-TRACKVIEW-1` — HIGH — Unauthenticated view-tracking writes a DB txn per call
+`POST /post/v1/track_view/{post_id}` is public, un-rate-limited, and `increment_view_count` opens a
+transaction + INSERTs a `post_view` row + UPDATEs the post **on every request** (`post/actions.rs:606`).
+No IP dedup, no cooldown. Anonymous loop → connection-pool/CPU/disk exhaustion. **Fix:** rate-limit
+the `/post/v1` nest (or the route), dedup per (post, ip/session) in Redis with a short TTL before any
+DB write.
+
+### `DOS-SEARCH-1` — MEDIUM — Unauthenticated, un-rate-limited, unindexed triple-ILIKE
+`POST /search/v1/search` (public) runs `Title/Excerpt/Slug.contains(q)` → three leading-wildcard
+`ILIKE '%q%'` (no usable index; the existing `tsvector`/GIN index is ignored), with an unbounded
+`page` → arbitrary `OFFSET`. The CSRF guard requires a token, but it is anonymously mintable once
+(`/csrf/v1/generate`) and stable/replayable, so the DoS stands. **Fix:** rate-limit `/search/v1`, cap
+`page`, and move to the tsvector/GIN full-text path that already exists in the schema.
+
+### `EMAIL-CHANGE-1` — MEDIUM — Email change does not reset `is_verified`
+`POST /user/v1/update` lets a verified user change their email to any unused address without resetting
+`is_verified` or re-verifying the new address (`user/actions.rs:142` sets only name/email/updated_at;
+the admin path at `:449` handles `is_verified`, confirming the self-service omission is unintended).
+The email UNIQUE constraint prevents takeover of an *existing* account, but a verified badge persists
+on an unproven email (trust-spoofing; misleads admin views, recovery eligibility, abuse attribution).
+**Fix:** on email change, set `is_verified=false`, `email_verification::Entity::regenerate` + mail the
+new address, and let `auth_guard::verified` drop the session back into the verification flow.
+
+### `SITEMAP-XML-1` — MEDIUM — Stored XML injection in `/sitemap.xml`
+`router.rs:238` interpolates the post `slug` (and `CONSUMER_SITE_URL`) raw into XML via `format!`.
+Slugs are only length-validated (`post_v1/validator.rs:270`), stored verbatim (`post/actions.rs:241`),
+and author-controlled — so an AUTHOR can store `</loc></url><!--` / `<script>` / `&` and inject
+arbitrary XML into the public sitemap. `feed_v1/mod.rs:56` already defines `xml_escape()` and uses it
+for RSS; the sitemap path omits it. **Fix:** escape `slug` + `base_url` with `xml_escape` (and add a
+charset/length cap + pagination to the sitemap query).
+
+### `AUTH-REVOKE-FAILOPEN-1` — LOW — Session-revocation check fails open on Redis errors
+`is_session_revoked` returns `Ok(false)` on a Redis `SISMEMBER` error (`auth.rs:462`); the extractor
+fail-opens too (`extractor.rs:299`). Documented (avoid mass lockout), but during a Redis partition a
+revoked cookie can keep authenticating up to the 14-day expiry, and the terminate-time `DEL` shares
+the same failure domain. **Fix (defense-in-depth):** add a fail-closed secondary check against
+`user_sessions.revoked_at` (Postgres, different failure domain) and alert on sustained
+revocation-check errors.
+
+### `DEPS-WEBPKI-1` — LOW — rustls-webpki 0.101.7 compiled into the default build (AWS SDK → rustls 0.21)
+Carries RUSTSEC-2026-0098/0099 (X.509 name-constraint bypass) on the server→S3 TLS path. Reachable in
+the default build (AWS SDK is a non-optional dep). Bounded by an operator trust boundary (requires
+MITM/control of `S3_ENDPOINT`); the CRL-panic advisory (0104) is **not reachable** (no CRL loading).
+Already documented/ignored in `deny.toml`. **Fix:** bump `aws-config`/`aws-sdk-s3` once a release
+pulls rustls 0.23 (pursued in the crate-update step).
+
+### `DEPS-NATIVE-TLS-1` — INFO — Mixed TLS stack (lettre/reqwest pull OpenSSL)
+`lettre` uses `tokio1-native-tls` and `reqwest` default features select native-tls, so the default
+build links OpenSSL while the rest of the stack is rustls. No open CVE (openssl 0.10.81 is current);
+hygiene only. **Fix:** `lettre` → `tokio1-rustls-tls`, `reqwest` → `default-features=false,
+["json","cookies","rustls-tls"]`.
+
+---
+
+## Feature-gated findings (`full` build only)
+
+### `PRIV-ESCAL-1` — HIGH — ADMIN can escalate any user to SUPER_ADMIN
+`/user/v1/admin/update/{id}` is gated only at `ROLE_ADMIN` (`user_v1/mod.rs:37`); the handler takes no
+`AuthSession` (`controller.rs:115`) and `User::admin_update` blindly `Set`s whatever role is supplied
+(`user/actions.rs:440`). An ADMIN POSTs `{"role":"super-admin"}` (validated only as a legal
+`UserRole`) and reaches `ROLE_SUPER_ADMIN`-only ACL/seed endpoints — defeating the top of the role
+hierarchy. Same gap in `admin_create`. (Not in default build; `admin_acl_v1`/`seed_v1` correctly use
+`ROLE_SUPER_ADMIN`, so `user_v1` is the inconsistent outlier.) **Fix:** inject the caller's
+`AuthSession` and reject when `target_role.to_i32() > caller.role_level()`; also block an ADMIN from
+mutating a user at/above their own level; add an `audit_log` row + regression test.
+
+### `DOS-COMMENTLIST-1` — MED — Public comment-list SELECT has no LIMIT (3-table join)
+`find_all_by_post` (`post_comment/actions.rs:108`) joins user+media, filters by post only, no
+`.limit()`; handler returns the whole Vec. Per-IP 100/min throttles one IP but the result set is
+unbounded and IP rotation removes the throttle. **Fix:** paginate (reuse `PER_PAGE`/`find_with_query`)
++ hard cap.
+
+### `DOS-COMMENT-CREATE-2` — MED — Comment create has only per-IP throttle, no per-account limiter
+Verified accounts behind rotating IPs create `100×N` comments/min with no per-user/per-post cap.
+Auth/newsletter/email-verification all call `abuse_limiter`; comment create uniquely omits it.
+**Fix:** `abuse_limiter` with a per-user (and per-post) key in `comment::create`.
+
+### `CSRF-GET-MUTATE-1` — LOW — State-mutating GET bypasses CSRF guard
+`/admin/route/v1/sync` is wired as `get(...)` (`admin_route_v1/mod.rs:19`) but runs Redis writes; the
+CSRF guard exempts all GETs (`static_csrf.rs:129`), and SameSite=Lax carries the cookie on top-level
+cross-site GETs. Limited impact (re-sync rebuilds cache from the DB) + ROLE_ADMIN. **Fix:** change to
+`post(...)` (requires matching admin-frontend change).
+
+### `BILLING-DEAD-VALIDATORS-1` — LOW — Billing uses raw `Json<>`, so all `#[validate]` rules are dead
+Every billing handler deserializes with axum `Json<T>` (never calls `.validate()`), so
+`range(min=1)`/`range(min=0)` checks never fire. Impact is bounded (admin-gated, and charged amounts
+are server-derived), but `post_id=-1`/negative prices reach the DB. **Fix:** switch to
+`ValidatedJson<T>` (crate-wide contract); add `range` to `SetPostAccessPayload.price_cents`.
+
+### `OPENREDIR-BILLING-1` — LOW — Unvalidated `success_url`/`cancel_url` forwarded to providers
+Acceptance has only a length check; verbatim URLs become provider post-checkout redirects (open
+redirect) and, for Mercado Pago, the `notification_url` (provider-mediated webhook SSRF). Not a direct
+server SSRF (the app never fetches them). **Fix:** validate http(s) + origin allow-list (reuse the
+`build_allowed_success_redirect` pattern from `google_auth_v1`); never derive Mercado Pago
+`notification_url` from user input.
+
+### `BILLING-METADATA-EXPOSE-1` — LOW — Consumer billing endpoints return the raw provider `metadata` blob
+`/billing/v1/subscriptions` & `/payments` are correctly user-filtered (no IDOR) but serialize the raw
+`Model` incl. `metadata` (payer email/address/phone) instead of the curated response structs that omit
+it. **Fix:** serialize through `SubscriptionResponse`/`PaymentResponse`.
+
+### `CRYPT-NEWSLETTER-1` — LOW — Newsletter token compared with `==` and stored plaintext
+`newsletter_subscriber/actions.rs:78/107` use `==`/`!=`; token is a plaintext UUIDv4. Inconsistent
+with the rest of the crypto surface (HMAC/2FA/CSRF all use `ConstantTimeEq`). 122-bit entropy makes
+remote timing infeasible; real residual risk is plaintext-at-rest. **Fix:** store as HMAC via
+`utils::code_hash::hash_code` + lookup by hash (and/or `ct_eq` compare).
+
+### `WEBHOOK-LS-RZP-NO-TIMESTAMP` — LOW — Lemon Squeezy/Razorpay webhooks have no replay protection
+Those providers send no timestamp, so `verify_webhook` HMACs only the body; a captured valid event is
+replayable. Not a forgery, and the single-use `GETDEL` checkout intent + `provider_payment_id` unique
+index neutralize double-grant — replay only re-runs idempotent no-ops. **Fix:** dedup on provider
+event id in a Redis SET with TTL at the top of `process_webhook_event`.
+
+### `DOS-NEWSLETTER-IP-1` — LOW — Newsletter subscribe throttle keyed only by email
+`abuse_limiter` key is the email (`newsletter_v1/controller.rs:78`); rotating emails sidesteps it; the
+coarse 100/min per-IP layer still permits ~100 inserts + 100 outbound emails/min/IP. **Fix:** add a
+per-IP `abuse_limiter` bucket alongside the per-email one.
+
+### `AUTH-ENUM-1` — LOW — User enumeration via distinct register response
+`register` returns 201 (new) vs 409 "Duplicate entry" (existing) (`auth_v1/controller.rs:432/437`),
+surfacing the raw SeaORM error. (Not in default build; `log_in` is timing-equalized.) **Fix:** return
+a generic identical message for both; do not surface the raw DB error.
+
+### `BILLING-ACCESS-INFO-1` — INFO — `/billing/v1/access/{id}` enumerates gated-post catalog
+Public, unauthenticated, un-rate-limited; returns price/tier for any post_id (incl. unpublished).
+Price is public storefront info; content is not leaked. **Fix (optional):** 404 for non-published
+ids + light rate limit.
+
+---
+
+## Recommended further work (not code-confirmed findings)
+- Apply a **global `DefaultBodyLimit`** on the router (limits are currently per-module and accidental).
+- Document the **HSTS-on-plaintext-listener** deployment assumption (the process serves HTTP; HSTS /
+  `Secure` cookies rely on an upstream TLS-terminating proxy).
+- Quarterly re-review of the 5 `deny.toml`/`audit.toml` accepted advisories with owners/tickets.
+
+## Methodology note
+All severities above were set by the *verifier*, not the auditor. The verifier repeatedly caught
+overstatements: it downgraded the search DoS's exploit framing (CSRF token is required but cheaply
+obtained), corrected the rustls-webpki severity (CRL-panic vector is unreachable), and disproved 5
+auditor findings outright. Two critic-flagged "gaps" were also disproved on manual review:
+password-change session revocation (**already done** via `session_auth_secret` rotation, F#16) and
+OAuth account-linking (**fail-closed** on unverified IdP email).
+
+---
+
+## Remediation applied this pass (2026-06-29)
+
+Build verified: `cargo check` (default + `full`) clean; `cargo test --lib` → **265 passed, 0 failed**.
+
+### ✅ Fixed (10)
+| Finding | Change |
+|---|---|
+| `SITEMAP-XML-1` | New `utils::sanitize::xml_escape`; `/sitemap.xml` escapes slug + base URL (default build). |
+| `AUTH-BF-1` | `log_in` now calls `abuse_limiter` keyed `login:{email}` (fail-closed) — per-account lockout on the password step (default build). |
+| `DOS-TRACKVIEW-1` | `/post/v1` nest given a 200/min/IP rate limit, bounding the per-call DB-txn view counter (default build). |
+| `DOS-SEARCH-1` | `/search/v1` given a 30/min/IP rate limit; `page` clamped to ≤500 to bound OFFSET (default build). |
+| `EMAIL-CHANGE-1` | `User::update` resets `is_verified=false` and rotates `session_auth_secret` (invalidating prior sessions) when the email actually changes (default build). |
+| `PRIV-ESCAL-1` | `admin_create`/`admin_update`/`admin_change_password` now take the caller's `AuthSession` and reject (a) assigning a role above your own and (b) touching a user at/above your own level (`user-management`). |
+| `DOS-COMMENTLIST-1` | `find_all_by_post` capped with `.limit(500)` (`comments`). |
+| `DOS-COMMENT-CREATE-2` | `comment::create` calls `abuse_limiter` keyed per user (`comments`). |
+| `DOS-NEWSLETTER-IP-1` | newsletter `subscribe` adds a per-IP `abuse_limiter` bucket alongside the per-email one (`newsletter`). |
+| `CRYPT-NEWSLETTER-1` | newsletter confirm/unsubscribe token compare switched to `subtle::ConstantTimeEq` (`newsletter`). |
+| `DEPS-NATIVE-TLS-1` | `lettre` → `tokio1-rustls-tls`, `reqwest` → `default-features=false` + `rustls-tls`. **OpenSSL (`native-tls`/`openssl-sys`) fully removed from the default build graph.** |
+| Crate refresh | `cargo update` (all deps latest semver-compatible); raised floors `axum 0.8.4→0.8.9`, `sea-orm 1.1.0→1.1.2`, `jsonwebtoken 10.2→10.4` (CVE-2026-25537 floor). |
+
+### 📋 Documented (deferred — wire-contract change or design trade-off; exact fix given)
+| Finding | Why deferred / fix |
+|---|---|
+| `CSRF-GET-MUTATE-1` | Change `/admin/route/v1/sync` `get→post` — requires the admin frontend to switch its call. **Coordinate with `frontend/admin-dioxus` before applying.** |
+| `BILLING-DEAD-VALIDATORS-1` | Swap `Json<T>`→`ValidatedJson<T>` in the 7 billing handlers (surfaces intended `range()` checks). Low risk; behind `billing`. |
+| `OPENREDIR-BILLING-1` | Validate `success_url`/`cancel_url` against an origin allow-list (reuse `google_auth_v1::build_allowed_success_redirect`); never derive Mercado Pago `notification_url` from user input. |
+| `BILLING-METADATA-EXPOSE-1` | Serialize consumer `/billing/v1/subscriptions` & `/payments` through `SubscriptionResponse`/`PaymentResponse` (omit `metadata`). |
+| `WEBHOOK-LS-RZP-NO-TIMESTAMP` | Dedup Lemon Squeezy/Razorpay events on provider event-id in a Redis SET w/ TTL at the top of `process_webhook_event`. (GETDEL + unique-index already neutralize forgery/double-grant.) |
+| `AUTH-ENUM-1` | Return one generic message for both register success and duplicate; don't surface the raw SeaORM error. (`log_in` is already timing-equalized.) |
+| `AUTH-REVOKE-FAILOPEN-1` | Add a fail-closed secondary check against `user_sessions.revoked_at` (Postgres) + alert on sustained revocation-check errors. Deliberate avail-vs-security trade-off — needs an operator decision. |
+| `DEPS-WEBPKI-1` | rustls-webpki 0.101.7 (AWS SDK→rustls 0.21). No rustls-0.21 patch exists; fix lands when the AWS SDK moves to rustls 0.23. Already documented/accepted in `deny.toml`; bounded by the S3-endpoint operator trust boundary. |
+| `BILLING-ACCESS-INFO-1` | Optional: 404 non-published ids + light rate limit on `/billing/v1/access/{id}`. |
+| Global body limit / HSTS-on-plaintext | Apply a global `DefaultBodyLimit`; document the HSTS/upstream-TLS-proxy deployment assumption. |
+


### PR DESCRIPTION
Independent 16-dimension security re-audit of `backend/api` (axum/SeaORM/Redis/rux-auth), with adversarial per-finding verification, a completeness critic, and a targeted re-find round (**60 agents, 2.58M tokens**). Full report: `docs/SECURITY_AUDIT_2026-06-30.md`.

## Headline
Authorization model is sound: **no cross-user IDOR** on any resource, **no reachable SQL injection**, OAuth/session/CSRF/crypto intact. This PR fixes every confirmed HIGH + MEDIUM plus the clean LOWs, and refreshes crates (incl. removing the AWS SDK legacy TLS CVE stack).

## Fixed
**HIGH**
- `IDOR-USER-ADMIN-DELETE` — `admin_delete` was the one gap in PRIV-ESCAL-1: an ADMIN could delete a SUPER_ADMIN. Now caller-level-checked.

**MEDIUM**
- `DOS-PUBLIST-OFFSET-1` — unbounded OFFSET on the public post list → clamped to ≤500.
- `DOS-TRACKVIEW-2` + `RACE-VIEWCOUNT-1` — per-(post,ip) Redis dedup before any DB write + atomic `view_count` increment.
- `OAUTH-CREATE-UNVERIFIED` — Google OAuth create now honors IdP `verified_email`.
- `SSRF-MP-NOTIFICATIONURL-1` — Mercado Pago `notification_url` no longer derived from user input.
- `ACL-ENV-SECRETS-IMPORT` — `import_env` skips secret keys (no more `COOKIE_KEY`/`FIELD_ENC_KEY`/`DATABASE_URL`/AWS creds duplicated to Postgres+Redis).
- `DOS-MEDIA-OPTIMIZER` — image decode moved to `spawn_blocking`, `/media/v1` rate-limited, pixel budget 40M→12M.
- `DEPS-AWS-SDK-LEGACY-TLS` — AWS SDK `default-features=false` ⇒ **rustls-0.21/webpki-0.101/hyper-0.14 removed** (RUSTSEC-2026-0098/0099/0104); stale `deny.toml` ignores deleted. Verified via `cargo tree`.

**LOW** — `SCHED-TOCTOU-AUTHZ` (scheduler re-checks author authz at fire time), `AUTH-ENUM-REGISTER` (no raw duplicate-error leak), `WEBHOOK-LS-RZP-NO-REPLAY-DEDUP` (24h body-hash dedup after sig verify).

**Deps** — removed unused `tower-sessions-core 0.9.0`; `cargo update`; floor bumps (`tokio`/`uuid`/`regex`/`serde`/`sea-orm`).

## Deferred (exact fix recipes in the audit doc)
`EMAIL-CHANGE-NO-REVERIFY-MAIL`, `2FA-BACKUP-TOCTOU`, `BILLING-DEAD-VALIDATORS`, `OPENREDIR-BILLING-1`, `BILLING-METADATA-EXPOSE`, `CRYPT-NEWSLETTER-PLAINTEXT-AT-REST`, `CSRF-GET-MUTATE-1` (frontend GET→POST), `2FA-DISABLE-NO-REAUTH`, `LOGIN-LOCKOUT-DOS` (trade-off vs the brute-force throttle). 6 auditor findings were refuted by verifiers (overstatements).

## Verification
`cargo check` clean (default + `full`); `cargo test --lib` → **265 + 539 passed, 0 failed**; `cargo tree` confirms the legacy TLS stack is gone.

> Note: behavioral fixes (dedup, atomic increment, OAuth gate, ACL skip) are verified by review + compile + unit tests; the live DB+Redis integration suite was not run in the audit environment.