### PR TITLE
ci: fix failing backend-ci, release-guard, web-release

### DIFF
--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -73,27 +73,37 @@ jobs:
         run: |
           set -euo pipefail
 
+          # The workspace shares a single target dir at the workspace root, NOT
+          # backend/api/target, so resolve it from `cargo metadata` instead of
+          # hard-coding a relative path (which previously pointed at a path that
+          # did not exist, making this grep a silent false-pass).
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')
+
           # Build the primary release artifact with the default feature set.
           cargo build --release --bin ruxlog
 
-          OBJ="target/release/ruxlog"
+          OBJ="$TARGET_DIR/release/ruxlog"
+          test -f "$OBJ" || { echo "::error::release binary not found at $OBJ"; exit 1; }
           if grep -aql "seed_v1\|services::seed::seeded_rng\|seed_config::SeedMode" "$OBJ"; then
             echo "::error::seed symbols leaked into the release ruxlog binary"
             exit 1
           fi
           echo "OK: no seed-system symbols found in the release binary."
 
-      - name: Explicitly fail if --features seed-system is requested for release
+      - name: Verify seed-system feature reachability (opt-in only)
         working-directory: backend/api
         run: |
           set -euo pipefail
-          # This is a guardrail: any caller that tries to build the *release*
-          # binary with seed-system enabled must be caught. We assert that the
-          # main release binary does not accept seed-system without explicitly
-          # opting into the gated TUI binary.
+          # Guardrail: confirm the seed-system feature, when explicitly enabled,
+          # actually wires the seed routes/symbols into the binary (feature
+          # reachability check). seed-system stays excluded from default/full
+          # (verified above), so it only ever lands here via an explicit
+          # `--features seed-system`.
+          TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | jq -r '.target_directory')
           if cargo build --release --features seed-system --bin ruxlog; then
             echo "::warning::ruxlog compiled with seed-system; verifying seed symbols are present (feature is reachable)"
-            OBJ="target/release/ruxlog"
+            OBJ="$TARGET_DIR/release/ruxlog"
+            test -f "$OBJ" || { echo "::error::release binary not found at $OBJ"; exit 1; }
             if ! grep -aql "seed_v1\|seeded_rng" "$OBJ"; then
               echo "::error::seed-system feature was enabled but produced no seed symbols (feature wiring is broken)"
               exit 1

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -56,7 +56,12 @@ jobs:
             --features "basic"
 
       - name: Rewrite paths for GitHub Pages subpath
-        working-directory: frontend/consumer-dioxus/target/dx/consumer-dioxus/release/web/public
+        # Dioxus 0.8 writes the web bundle to the *workspace-root* target dir
+        # (cargo resolves the ruxlog workspace root from any member), so the
+        # static client output lands at target/dx/consumer-dioxus/release/web/public
+        # — NOT under frontend/consumer-dioxus/target. This path is relative to
+        # the repo root (GITHUB_WORKSPACE).
+        working-directory: target/dx/consumer-dioxus/release/web/public
         run: |
           BASE="/ruxlog"
           # Normalize /./assets/ to /assets/ first
@@ -71,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: consumer-web
-          path: frontend/consumer-dioxus/target/dx/consumer-dioxus/release/web/public
+          path: target/dx/consumer-dioxus/release/web/public
           if-no-files-found: error
           retention-days: 1
 

--- a/backend/api/src/db/sea_models/newsletter_subscriber/actions.rs
+++ b/backend/api/src/db/sea_models/newsletter_subscriber/actions.rs
@@ -80,12 +80,7 @@ impl Entity {
             // lone `==` outlier). subtle is a direct dep and compiles without
             // the billing feature, unlike services::billing::webhook_util.
             use subtle::ConstantTimeEq;
-            let token_ok = model
-                .token
-                .as_bytes()
-                .ct_eq(token.as_bytes())
-                .unwrap_u8()
-                == 1;
+            let token_ok = model.token.as_bytes().ct_eq(token.as_bytes()).unwrap_u8() == 1;
             if token_ok && model.status != SubscriberStatus::Unsubscribed {
                 let mut am: ActiveModel = model.into();
                 am.status = Set(SubscriberStatus::Confirmed);

--- a/backend/api/src/db/sea_models/user/actions.rs
+++ b/backend/api/src/db/sea_models/user/actions.rs
@@ -157,16 +157,14 @@ impl Entity {
                     // email-verification resend endpoint.
                     user_active.email = Set(email);
                     user_active.is_verified = Set(false);
-                    user_active.session_auth_secret =
-                        Set(super::model::new_session_auth_secret().map_err(|err| {
+                    user_active.session_auth_secret = Set(super::model::new_session_auth_secret()
+                        .map_err(|err| {
                             error!(
                                 user_id,
                                 "session_auth_secret rotation failed during email change: {err}"
                             );
                             ErrorResponse::new(ErrorCode::InternalServerError)
-                                .with_message(format!(
-                                    "session_auth_secret rotation failed: {err}"
-                                ))
+                                .with_message(format!("session_auth_secret rotation failed: {err}"))
                         })?);
                     info!(
                         user_id,

--- a/backend/api/src/main.rs
+++ b/backend/api/src/main.rs
@@ -1,4 +1,6 @@
-use axum::{extract::State, http::HeaderName, middleware, Extension};
+#[cfg(feature = "admin-acl")]
+use axum::extract::State;
+use axum::{http::HeaderName, middleware, Extension};
 use axum_client_ip::ClientIpSource;
 use axum_extra::extract::cookie::SameSite;
 use std::{env, net::SocketAddr, time::Duration};
@@ -46,6 +48,7 @@ fn env_bool(key: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
+#[cfg_attr(not(feature = "full"), allow(dead_code))]
 fn env_u64(key: &str, default: u64) -> u64 {
     env::var(key)
         .ok()
@@ -53,6 +56,7 @@ fn env_u64(key: &str, default: u64) -> u64 {
         .unwrap_or(default)
 }
 
+#[cfg_attr(not(feature = "full"), allow(dead_code))]
 fn env_u8(key: &str, default: u8) -> u8 {
     let candidate = env::var(key)
         .ok()
@@ -548,6 +552,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // per-request session-revocation `SISMEMBER`.
     let redis_extension = Extension(state.redis_pool.clone());
 
+    #[cfg_attr(not(feature = "full"), allow(unused_mut))]
     let mut app = router::router(state.clone())
         .layer(ip_source.into_extension())
         .layer(db_extension)

--- a/backend/api/src/modules/analytics_v1/validator.rs
+++ b/backend/api/src/modules/analytics_v1/validator.rs
@@ -1341,6 +1341,5 @@ mod tests {
     fn constants_are_sensible() {
         assert_eq!(DEFAULT_PER_PAGE, 30);
         assert_eq!(MAX_PER_PAGE, 200);
-        assert!(MAX_PER_PAGE > DEFAULT_PER_PAGE);
     }
 }

--- a/backend/api/src/modules/auth_v1/controller.rs
+++ b/backend/api/src/modules/auth_v1/controller.rs
@@ -9,10 +9,12 @@ use axum_macros::debug_handler;
 use axum_client_ip::ClientIp;
 
 use rux_auth::AuthBackend as AuthBackendTrait;
+#[cfg_attr(not(feature = "full"), allow(unused_imports))]
 use sea_orm::{ActiveModelTrait, EntityTrait};
 use serde_json::json;
 use tracing::{error, info, instrument, warn};
 
+#[cfg_attr(not(feature = "full"), allow(unused_imports))]
 use crate::{
     db::sea_models::{email_verification, user, user_session},
     error::{ErrorCode, ErrorResponse},
@@ -911,6 +913,7 @@ fn session_mapping_key(pg_session_id: i32) -> String {
 /// a 500 here would mislead the client about an otherwise-complete operation.
 /// `auth` is taken by `&mut` only so the borrow checker allows a subsequent
 /// `auth.session()` call; the mutation is to interior session state.
+#[cfg_attr(not(feature = "full"), allow(dead_code))]
 async fn rotate_session_after_trust_change(auth: &mut AuthSession) {
     if let Err(err) = auth.session().cycle_id().await {
         warn!(error = %err, "F#16: failed to re-rotate session id at trust transition; CSRF token NOT rebound");

--- a/backend/api/src/modules/auth_v1/mod.rs
+++ b/backend/api/src/modules/auth_v1/mod.rs
@@ -6,6 +6,7 @@ use axum::{middleware, routing::post, Router};
 use crate::{middlewares::auth_guard, AppState};
 
 pub fn routes() -> Router<AppState> {
+    #[cfg_attr(not(feature = "user-management"), allow(unused_mut))]
     let mut public = Router::<AppState>::new()
         .route("/log_in", post(controller::log_in))
         // Second step of the two-step 2FA-at-login flow (F#4/F#7/F#16): a
@@ -23,6 +24,7 @@ pub fn routes() -> Router<AppState> {
 
     let public = public.route_layer(middleware::from_fn(auth_guard::unauthenticated));
 
+    #[cfg_attr(not(feature = "auth-2fa"), allow(unused_mut))]
     let mut authenticated = Router::<AppState>::new().route("/log_out", post(controller::log_out));
 
     #[cfg(feature = "auth-2fa")]

--- a/backend/api/src/modules/google_auth_v1/service.rs
+++ b/backend/api/src/modules/google_auth_v1/service.rs
@@ -318,6 +318,7 @@ impl IdTokenError {
 /// [`verify_id_token_with_keys_core`] directly. `#[cfg(test)]` keeps it out of
 /// the non-test build (where it would otherwise be dead code).
 #[cfg(test)]
+#[allow(clippy::result_large_err)] // test-only thin wrapper; ErrorResponse is the domain error type
 fn verify_id_token_with_keys(
     id_token: &str,
     keys: &[GoogleJwkKey],

--- a/backend/api/src/modules/media_v1/controller.rs
+++ b/backend/api/src/modules/media_v1/controller.rs
@@ -22,7 +22,6 @@ use crate::{
         category::{self, Model as CategoryModel},
         media::{self, Entity as Media, NewMedia},
         media_usage,
-        media_variant::{Entity as MediaVariant, NewMediaVariant},
         post::{self, Model as PostModel},
         user::{self, Model as UserModel},
     },
@@ -33,11 +32,15 @@ use crate::{
 };
 
 #[cfg(feature = "image-optimization")]
+use crate::db::sea_models::media_variant::{Entity as MediaVariant, NewMediaVariant};
+#[cfg(feature = "image-optimization")]
 use crate::services::image_optimizer;
 use tracing::{debug, error, info, instrument, warn};
 
+#[cfg(feature = "image-optimization")]
+use super::validator::is_allowed_mime;
 use super::validator::{
-    allowlisted_extension, is_allowed_mime, validate_upload, MediaUploadMetadata, V1MediaListQuery,
+    allowlisted_extension, validate_upload, MediaUploadMetadata, V1MediaListQuery,
     V1MediaUsageQuery,
 };
 
@@ -293,10 +296,15 @@ pub async fn create(
         }
     }
 
+    #[cfg_attr(not(feature = "image-optimization"), allow(unused_mut))]
     let mut extension = Some(declared_extension.clone());
+    #[cfg_attr(not(feature = "image-optimization"), allow(unused_mut))]
     let mut content_type = declared_mime.clone();
+    #[cfg_attr(not(feature = "image-optimization"), allow(unused_mut))]
     let mut final_bytes = file_bytes.clone();
+    #[cfg_attr(not(feature = "image-optimization"), allow(unused_mut))]
     let mut is_optimized = false;
+    #[cfg_attr(not(feature = "image-optimization"), allow(unused_mut))]
     let mut optimized_at = None;
 
     #[cfg(feature = "image-optimization")]
@@ -331,33 +339,32 @@ pub async fn create(
         let req_mime = mime_type.clone();
         let req_ext = extension.clone();
         let optimizer_cfg = state.optimizer.clone();
-        let optimization_outcome =
-            match tokio::task::spawn_blocking(move || {
-                let optimization_request = image_optimizer::OptimizationRequest {
-                    bytes: &req_bytes,
-                    metadata: &req_metadata,
-                    reference: req_reference,
-                    original_mime: req_mime.as_deref(),
-                    original_extension: req_ext.as_deref(),
-                };
-                image_optimizer::optimize(&optimizer_cfg, optimization_request)
-            })
-            .await
-            {
-                Ok(Ok(outcome)) => outcome,
-                Ok(Err(err)) => {
-                    warn!("image optimizer error: {}", err);
-                    image_optimizer::OptimizationOutcome::Skipped(
-                        image_optimizer::SkipReason::DecodeFailed,
-                    )
-                }
-                Err(err) => {
-                    warn!(error = %err, "image optimizer blocking task failed");
-                    image_optimizer::OptimizationOutcome::Skipped(
-                        image_optimizer::SkipReason::DecodeFailed,
-                    )
-                }
+        let optimization_outcome = match tokio::task::spawn_blocking(move || {
+            let optimization_request = image_optimizer::OptimizationRequest {
+                bytes: &req_bytes,
+                metadata: &req_metadata,
+                reference: req_reference,
+                original_mime: req_mime.as_deref(),
+                original_extension: req_ext.as_deref(),
             };
+            image_optimizer::optimize(&optimizer_cfg, optimization_request)
+        })
+        .await
+        {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(err)) => {
+                warn!("image optimizer error: {}", err);
+                image_optimizer::OptimizationOutcome::Skipped(
+                    image_optimizer::SkipReason::DecodeFailed,
+                )
+            }
+            Err(err) => {
+                warn!(error = %err, "image optimizer blocking task failed");
+                image_optimizer::OptimizationOutcome::Skipped(
+                    image_optimizer::SkipReason::DecodeFailed,
+                )
+            }
+        };
 
         if let image_optimizer::OptimizationOutcome::Optimized(result) = optimization_outcome {
             // M-7 defense-in-depth: never trust a Content-Type/extension that
@@ -392,6 +399,7 @@ pub async fn create(
     })?;
 
     let object_key = build_object_key(extension.as_deref());
+    #[cfg(feature = "image-optimization")]
     let base_object_key = object_key
         .rsplit_once('.')
         .map(|(prefix, _)| prefix.to_string())

--- a/backend/api/src/modules/media_v1/validator.rs
+++ b/backend/api/src/modules/media_v1/validator.rs
@@ -268,8 +268,10 @@ mod tests {
 
     #[test]
     fn apply_field_reference_type_empty_clears() {
-        let mut meta = MediaUploadMetadata::default();
-        meta.reference_type = Some(MediaReference::Category);
+        let mut meta = MediaUploadMetadata {
+            reference_type: Some(MediaReference::Category),
+            ..Default::default()
+        };
 
         meta.apply_field("reference_type", "  ").unwrap();
         assert!(meta.reference_type.is_none());
@@ -303,8 +305,10 @@ mod tests {
 
     #[test]
     fn apply_field_width_empty_clears() {
-        let mut meta = MediaUploadMetadata::default();
-        meta.width = Some(800);
+        let mut meta = MediaUploadMetadata {
+            width: Some(800),
+            ..Default::default()
+        };
 
         meta.apply_field("width", "").unwrap();
         assert!(meta.width.is_none());
@@ -329,8 +333,10 @@ mod tests {
 
     #[test]
     fn apply_field_height_empty_clears() {
-        let mut meta = MediaUploadMetadata::default();
-        meta.height = Some(600);
+        let mut meta = MediaUploadMetadata {
+            height: Some(600),
+            ..Default::default()
+        };
 
         meta.apply_field("height", "  ").unwrap();
         assert!(meta.height.is_none());

--- a/backend/api/src/modules/user_v1/controller.rs
+++ b/backend/api/src/modules/user_v1/controller.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(not(feature = "full"), allow(unused_imports))]
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -9,6 +10,7 @@ use serde_json::json;
 use tracing::{error, info, instrument, warn};
 
 use super::validator::*;
+#[cfg_attr(not(feature = "full"), allow(unused_imports))]
 use crate::{
     db::sea_models::user::{Entity as User, UserRole},
     error::{ErrorCode, ErrorResponse},
@@ -75,16 +77,11 @@ pub async fn admin_create(
     // an admin cannot create a user whose role exceeds their own — otherwise an
     // ADMIN could mint a SUPER_ADMIN, defeating the top tier that admin_acl_v1
     // / seed_v1 gate with ROLE_SUPER_ADMIN.
-    let caller_level = auth
-        .user
-        .as_ref()
-        .map(|u| u.role.to_i32())
-        .ok_or_else(|| {
-            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
-        })?;
-    let requested = UserRole::from_str(&payload.0.role).map_err(|_| {
-        ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role")
+    let caller_level = auth.user.as_ref().map(|u| u.role.to_i32()).ok_or_else(|| {
+        ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
     })?;
+    let requested = UserRole::from_str(&payload.0.role)
+        .map_err(|_| ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role"))?;
     if requested.to_i32() > caller_level {
         warn!(
             caller_level,
@@ -178,17 +175,14 @@ pub async fn admin_update(
     // silent takeover primitive an admin had by editing/demoting a superior. An
     // admin still manages their own profile via the self-service
     // /user/v1/update endpoint, so blocking equal-rank edits here is safe.
-    let caller_level = auth
-        .user
-        .as_ref()
-        .map(|u| u.role.to_i32())
-        .ok_or_else(|| {
-            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
-        })?;
+    let caller_level = auth.user.as_ref().map(|u| u.role.to_i32()).ok_or_else(|| {
+        ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+    })?;
 
     if let Some(role_str) = payload.0.role.as_deref() {
-        let requested = UserRole::from_str(role_str)
-            .map_err(|_| ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role"))?;
+        let requested = UserRole::from_str(role_str).map_err(|_| {
+            ErrorResponse::new(ErrorCode::InvalidInput).with_message("Invalid role")
+        })?;
         if requested.to_i32() > caller_level {
             warn!(
                 caller_level,
@@ -249,13 +243,9 @@ pub async fn admin_change_password(
     // PRIV-ESCAL-1: forbid resetting the password of a user at/above the
     // caller's own level — otherwise an ADMIN could set a known password on a
     // SUPER_ADMIN account (account takeover of a superior).
-    let caller_level = auth
-        .user
-        .as_ref()
-        .map(|u| u.role.to_i32())
-        .ok_or_else(|| {
-            ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
-        })?;
+    let caller_level = auth.user.as_ref().map(|u| u.role.to_i32()).ok_or_else(|| {
+        ErrorResponse::new(ErrorCode::Unauthorized).with_message("Not authenticated")
+    })?;
     if let Some(target) = User::get_by_id(&state.sea_db, user_id).await? {
         if target.role.to_i32() >= caller_level {
             warn!(
@@ -263,8 +253,11 @@ pub async fn admin_change_password(
                 target_level = target.role.to_i32(),
                 "Admin attempted to reset password of an equal/higher-role user"
             );
-            return Err(ErrorResponse::new(ErrorCode::OperationNotAllowed)
-                .with_message("You cannot reset the password of a user at or above your own role"));
+            return Err(
+                ErrorResponse::new(ErrorCode::OperationNotAllowed).with_message(
+                    "You cannot reset the password of a user at or above your own role",
+                ),
+            );
         }
     }
     User::change_password(&state.sea_db, user_id, payload.0.password).await?;

--- a/backend/api/src/services/abuse_limiter.rs
+++ b/backend/api/src/services/abuse_limiter.rs
@@ -274,8 +274,7 @@ pub async fn dedup_nx(
     key: &str,
     ttl_secs: usize,
 ) -> Result<bool, ErrorResponse> {
-    const DEDUP: &str =
-        "return redis.call('SET', KEYS[1], '1', 'EX', ARGV[1], 'NX') and 1 or 0";
+    const DEDUP: &str = "return redis.call('SET', KEYS[1], '1', 'EX', ARGV[1], 'NX') and 1 or 0";
     let keys = vec![key.to_string()];
     let args: Vec<Value> = vec![Value::from(ttl_secs as i64)];
     let res: Result<Vec<Value>, _> = redis_pool.eval(DEDUP, keys, args).await;

--- a/backend/api/src/services/billing/mercado_pago.rs
+++ b/backend/api/src/services/billing/mercado_pago.rs
@@ -156,11 +156,12 @@ impl BillingProvider for MercadoPagoProvider {
             .map(|u| u.trim().to_string())
             .filter(|u| !u.is_empty())
             .or_else(|| {
-                std::env::var("CONSUMER_SITE_URL")
-                    .ok()
-                    .map(|base| {
-                        format!("{}/billing/v1/webhook/mercado_pago", base.trim_end_matches('/'))
-                    })
+                std::env::var("CONSUMER_SITE_URL").ok().map(|base| {
+                    format!(
+                        "{}/billing/v1/webhook/mercado_pago",
+                        base.trim_end_matches('/')
+                    )
+                })
             });
 
         let mut body = serde_json::json!({

--- a/backend/api/src/services/scheduler.rs
+++ b/backend/api/src/services/scheduler.rs
@@ -73,8 +73,8 @@ async fn publish_due_posts(state: &AppState) -> Result<(), sea_orm::DbErr> {
         };
         if !author_ok {
             warn!(
-                post_id, author_id,
-                "Skipping scheduled publish: author no longer authorized"
+                post_id,
+                author_id, "Skipping scheduled publish: author no longer authorized"
             );
             continue;
         }

--- a/backend/api/src/state.rs
+++ b/backend/api/src/state.rs
@@ -457,7 +457,7 @@ mod tests {
         let prev = std::env::var("FIELD_ENC_KEY").ok();
         std::env::set_var("FIELD_ENC_KEY", "too-short");
 
-        let result = std::panic::catch_unwind(|| load_field_enc_key());
+        let result = std::panic::catch_unwind(load_field_enc_key);
         assert!(
             result.is_err(),
             "load_field_enc_key must panic on a non-32-byte key"


### PR DESCRIPTION
## What

Three workflows are red on `master` after the 2026-06 security-audit merge (#57). This fixes all three at the root cause.

| Workflow | Root cause | Fix |
|---|---|---|
| **backend-ci** | `cargo fmt --check` failed on the audit changes; the step ran before clippy/test, masking downstream `clippy -D warnings` failures | `cargo fmt` the audit files + resolve all clippy lints |
| **release-guard** | grepped `target/release/ruxlog` relative to `backend/api`, but the binary builds at the **workspace-root** target dir → file never existed → step 2 silently false-passed, step 3 errored | resolve the target dir via `cargo metadata` + `test -f` guards |
| **web-release** | dioxus 0.8 (#56) writes the web bundle to the **workspace-root** `target/dx/.../web/public`; the Pages rewrite/upload still pointed at the pre-0.8 `frontend/consumer-dioxus/target/...` path | drop the `frontend/consumer-dioxus/` prefix |

## backend-ci detail
The audit introduced imports / vars / `mut` / dead-code used **only** by `full`-gated code (image-optimization variants, 2FA/OAuth, user-management, admin-acl/admin-routes). Under the minimal `basic` feature set these trip `clippy -D warnings`. Each is annotated with a precise `#[cfg_attr(not(feature = "..."), allow(...))]` (or cfg-gated import) so both configs stay clean without weakening `full`. Real lints in test code are fixed properly (struct-update syntax, redundant closure, `result_large_err`, `assertions_on_constants`).

## Verification
Ran the full backend-ci matrix locally — all green:
- `cargo fmt --check` ✅
- `cargo clippy {basic,full} -- -D warnings` ✅ (also `--all-targets`) ✅
- `cargo check {basic,full}` ✅
- `cargo test --features full` ✅
- `cargo test --test security_tests` ✅ (12 passed, default features)

release-guard and web-release are verified by root-cause analysis against the CI logs; the definitive check is this PR's CI run.

## Note
The `wasm-opt failed (SIGABRT)` line in the web-release build log is non-fatal (dioxus continues with the unoptimized wasm) and is **not** the cause of the failure — flagged separately for a future cleanup.
